### PR TITLE
Add branch trigger filter on GitHub release worklow

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -16,6 +16,8 @@ name: Create Github release
 
 on:
   push:
+    branches:
+      - 'main'
     tags:
       - '*'
 


### PR DESCRIPTION
The GitHub release workflow wasn't being triggered on tag pushes since it wasn't directly making changes to the 'main' branch. If we filter to run on tag changes on the release branch, it will trigger.

See: https://github.com/orgs/community/discussions/26840#discussioncomment-3253607
