### PR TITLE
Trigger GitHub release workflow on hierarchical tags

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -17,7 +17,7 @@ name: Create Github release
 on:
   push:
     tags:
-      - '*'
+      - '**'
 
 permissions:
   contents: write


### PR DESCRIPTION
Trigger the GitHub release workflow on hierarchical tags (tags that include `/`)
