### PR TITLE
Add a request option for custom headers

### DIFF
--- a/.changeset/strange-papayas-accept.md
+++ b/.changeset/strange-papayas-accept.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": minor
+---
+
+Add a request option for custom headers

--- a/packages/main/src/errors.ts
+++ b/packages/main/src/errors.ts
@@ -57,6 +57,10 @@ export class GoogleGenerativeAIFetchError extends GoogleGenerativeAIError {
 }
 
 /**
+ */
+export class GoogleGenerativeAIRequestInputError extends GoogleGenerativeAIError {}
+
+/**
  * Details object that may be included in an error response.
  * @public
  */

--- a/packages/main/src/requests/request.test.ts
+++ b/packages/main/src/requests/request.test.ts
@@ -155,6 +155,56 @@ describe("request methods", () => {
       );
       expect(request.fetchOptions.signal).to.be.instanceOf(AbortSignal);
     });
+    it("passes custom headers", async () => {
+      const request = await constructRequest(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        true,
+        "",
+        {
+          customHeaders: new Headers({ customerHeader: "customerHeaderValue" }),
+        },
+      );
+      expect(
+        (request.fetchOptions.headers as Headers).get("customerHeader"),
+      ).to.equal("customerHeaderValue");
+    });
+    it("passes custom x-goog-api-client header", async () => {
+      const request = await constructRequest(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        true,
+        "",
+        {
+          customHeaders: new Headers({ "x-goog-api-client": "client/version" }),
+        },
+      );
+      expect(
+        (request.fetchOptions.headers as Headers).get("x-goog-api-client"),
+      ).to.equal("genai-js/__PACKAGE_VERSION__, client/version");
+    });
+    it("passes apiClient and custom x-goog-api-client header", async () => {
+      const request = await constructRequest(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        true,
+        "",
+        {
+          apiClient: "client/version",
+          customHeaders: new Headers({
+            "x-goog-api-client": "client/version2",
+          }),
+        },
+      );
+      expect(
+        (request.fetchOptions.headers as Headers).get("x-goog-api-client"),
+      ).to.equal(
+        "client/version genai-js/__PACKAGE_VERSION__, client/version2",
+      );
+    });
   });
   describe("_makeRequestInternal", () => {
     it("no error", async () => {

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -76,6 +76,16 @@ export async function getHeaders(url: RequestUrl): Promise<Headers> {
   headers.append("Content-Type", "application/json");
   headers.append("x-goog-api-client", getClientHeaders(url.requestOptions));
   headers.append("x-goog-api-key", url.apiKey);
+
+  if (url.requestOptions.customHeaders) {
+    for (const [
+      headerName,
+      headerValue,
+    ] of url.requestOptions.customHeaders.entries()) {
+      headers.append(headerName, headerValue);
+    }
+  }
+
   return headers;
 }
 

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -77,11 +77,21 @@ export async function getHeaders(url: RequestUrl): Promise<Headers> {
   headers.append("x-goog-api-client", getClientHeaders(url.requestOptions));
   headers.append("x-goog-api-key", url.apiKey);
 
-  if (url.requestOptions.customHeaders) {
-    for (const [
-      headerName,
-      headerValue,
-    ] of url.requestOptions.customHeaders.entries()) {
+  let customHeaders = url.requestOptions.customHeaders;
+  if (customHeaders) {
+    if (!(customHeaders instanceof Headers)) {
+      try {
+        customHeaders = new Headers(customHeaders);
+      } catch (e) {
+        throw new GoogleGenerativeAIError(
+          `unable to convert customHeaders value ${JSON.stringify(
+            customHeaders,
+          )} to Headers: ${e.message}`,
+        );
+      }
+    }
+
+    for (const [headerName, headerValue] of customHeaders.entries()) {
       headers.append(headerName, headerValue);
     }
   }

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -93,12 +93,13 @@ export async function getHeaders(url: RequestUrl): Promise<Headers> {
     }
 
     for (const [headerName, headerValue] of customHeaders.entries()) {
-      if (
-        headerName === "x-goog-api-client" ||
-        headerName === "x-goog-api-key"
-      ) {
+      if (headerName === "x-goog-api-key") {
         throw new GoogleGenerativeAIRequestInputError(
-          `cannot set reserved header name ${headerName}`,
+          `Cannot set reserved header name ${headerName}`,
+        );
+      } else if (headerName === "x-goog-api-client") {
+        throw new GoogleGenerativeAIRequestInputError(
+          `Header name ${headerName} can only be set using the apiClient field`,
         );
       }
 

--- a/packages/main/types/requests.ts
+++ b/packages/main/types/requests.ts
@@ -139,7 +139,7 @@ export interface RequestOptions {
   /**
    * Custom HTTP request headers.
    */
-  customHeaders?: Headers;
+  customHeaders?: Headers | Record<string, string>;
 }
 
 /**

--- a/packages/main/types/requests.ts
+++ b/packages/main/types/requests.ts
@@ -136,6 +136,10 @@ export interface RequestOptions {
    * Base endpoint url. Defaults to "https://generativelanguage.googleapis.com"
    */
   baseUrl?: string;
+  /**
+   * Custom HTTP request headers.
+   */
+  customHeaders?: Headers;
 }
 
 /**


### PR DESCRIPTION
Allow users to pass custom request headers through request options.

Questions:
- If a user passes a `customHeaders` object that isn't a `Header` (e.g. `customHeaders:  { headerName: 'headerValue'}`, rather than `customHeaders: new Headers({ headerName: 'headerValue' })`), should we _a)_ raise a `TypeError: url.requestOptions.customHeaders.entries is not a function`, or _b)_ Ignore the custom headers?
- The original CL adds checks for newlines in `apiClient` and `customHeaders` fields. Should these checks be added to this PR, or a separate one?