### PR TITLE
Route support questions to discourse forum

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+**Note:** If this is a support question (e.g. _How do I do XYZ?_), please visit the [Discourse forum](https://discuss.ai.google.dev/). This is a great place to interact with developers, and to learn, share, and support each other.
+
 ## Expected Behavior
 
 


### PR DESCRIPTION
Updating github issue template to route support questions to [Discourse forum](https://discuss.ai.google.dev/)
