### PR TITLE
Add docs check workflow

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Doc Change Check (Run "yarn docs" if this fails)
+
+on: pull_request
+
+jobs:
+  doc-check:
+    name: Check if reference docs have changed
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        # get all history for the diff
+        fetch-depth: 0
+    - name: Set up Node (18)
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Yarn install
+      run: yarn
+    - name: Run doc generation
+      run: yarn docs
+    - name: Check for changes in docs-devsite dir (fail if so)
+      run: git diff --exit-code docs/reference
+    - name: Reference documentation needs to be updated. See message below.
+      if: ${{ failure() }}
+      run: echo "Changes in this PR affect the reference docs. Run \`yarn docs\` locally to regenerate docs and add them to this PR."


### PR DESCRIPTION
Checks if reference docs need to be generated but haven't been.

Copied and modified from https://github.com/firebase/firebase-js-sdk/blob/master/.github/workflows/check-docs.yml