### PR TITLE
Fix bug when no file name is provided for upload

### DIFF
--- a/.changeset/dirty-pillows-vanish.md
+++ b/.changeset/dirty-pillows-vanish.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix a bug that caused file uploads to be named "undefined" if no file name is provided.

--- a/packages/main/src/files/file-manager.test.ts
+++ b/packages/main/src/files/file-manager.test.ts
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 import { expect, use } from "chai";
-import { GoogleAIFileManager } from "./file-manager";
+import { GoogleAIFileManager, getUploadMetadata } from "./file-manager";
 import * as sinonChai from "sinon-chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { restore, stub } from "sinon";
 import * as request from "./request";
 import { FilesTask } from "./constants";
 import { DEFAULT_API_VERSION } from "../requests/request";
+import { FileMetadata } from "./types";
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -253,5 +254,39 @@ describe("GoogleAIFileManager", () => {
     await expect(fileManager.deleteFile("")).to.be.rejectedWith(
       "Invalid fileId",
     );
+  });
+
+  describe("getUploadMetadata", () => {
+    it("getUploadMetadata with only mimeType", () => {
+      const uploadMetadata = getUploadMetadata({ mimeType: "image/jpeg" });
+      expect(uploadMetadata.mimeType).to.equal("image/jpeg");
+      expect(uploadMetadata.displayName).be.undefined;
+      expect(uploadMetadata.name).be.undefined;
+    });
+    it("getUploadMetadata with no mimeType", () => {
+      expect(() => getUploadMetadata({} as FileMetadata)).to.throw(
+        "Must provide a mimeType.",
+      );
+    });
+    it("getUploadMetadata with all fields defined", () => {
+      const uploadMetadata = getUploadMetadata({
+        mimeType: "image/jpeg",
+        displayName: "display name",
+        name: "filename",
+      });
+      expect(uploadMetadata.mimeType).to.equal("image/jpeg");
+      expect(uploadMetadata.displayName).to.equal("display name");
+      expect(uploadMetadata.name).to.equal("files/filename");
+    });
+    it("getUploadMetadata with full file path", () => {
+      const uploadMetadata = getUploadMetadata({
+        mimeType: "image/jpeg",
+        displayName: "display name",
+        name: "custom/path/filename",
+      });
+      expect(uploadMetadata.mimeType).to.equal("image/jpeg");
+      expect(uploadMetadata.displayName).to.equal("display name");
+      expect(uploadMetadata.name).to.equal("custom/path/filename");
+    });
   });
 });

--- a/packages/main/src/files/file-manager.ts
+++ b/packages/main/src/files/file-manager.ts
@@ -26,7 +26,10 @@ import {
   UploadFileResponse,
 } from "./types";
 import { FilesTask } from "./constants";
-import { GoogleGenerativeAIError, GoogleGenerativeAIRequestInputError } from "../errors";
+import {
+  GoogleGenerativeAIError,
+  GoogleGenerativeAIRequestInputError,
+} from "../errors";
 
 // Internal type, metadata sent in the upload
 export interface UploadMetadata {
@@ -166,11 +169,11 @@ function generateBoundary(): string {
 
 export function getUploadMetadata(inputMetadata: FileMetadata): FileMetadata {
   if (!inputMetadata.mimeType) {
-    throw new GoogleGenerativeAIRequestInputError('Must provide a mimeType.');
+    throw new GoogleGenerativeAIRequestInputError("Must provide a mimeType.");
   }
   const uploadMetadata: FileMetadata = {
     mimeType: inputMetadata.mimeType,
-    displayName: inputMetadata.displayName
+    displayName: inputMetadata.displayName,
   };
 
   if (inputMetadata.name) {

--- a/packages/main/src/files/file-manager.ts
+++ b/packages/main/src/files/file-manager.ts
@@ -26,7 +26,7 @@ import {
   UploadFileResponse,
 } from "./types";
 import { FilesTask } from "./constants";
-import { GoogleGenerativeAIError } from "../errors";
+import { GoogleGenerativeAIError, GoogleGenerativeAIRequestInputError } from "../errors";
 
 // Internal type, metadata sent in the upload
 export interface UploadMetadata {
@@ -66,13 +66,7 @@ export class GoogleAIFileManager {
       `multipart/related; boundary=${boundary}`,
     );
 
-    const uploadMetadata: FileMetadata = {
-      mimeType: fileMetadata.mimeType,
-      displayName: fileMetadata.displayName,
-      name: fileMetadata.name?.includes("/")
-        ? fileMetadata.name
-        : `files/${fileMetadata.name}`,
-    };
+    const uploadMetadata = getUploadMetadata(fileMetadata);
 
     // Multipart formatting code taken from @firebase/storage
     const metadataString = JSON.stringify({ file: uploadMetadata });
@@ -168,4 +162,21 @@ function generateBoundary(): string {
     str = str + Math.random().toString().slice(2);
   }
   return str;
+}
+
+export function getUploadMetadata(inputMetadata: FileMetadata): FileMetadata {
+  if (!inputMetadata.mimeType) {
+    throw new GoogleGenerativeAIRequestInputError('Must provide a mimeType.');
+  }
+  const uploadMetadata: FileMetadata = {
+    mimeType: inputMetadata.mimeType,
+    displayName: inputMetadata.displayName
+  };
+
+  if (inputMetadata.name) {
+    uploadMetadata.name = inputMetadata.name.includes("/")
+      ? inputMetadata.name
+      : `files/${inputMetadata.name}`;
+  }
+  return uploadMetadata;
 }


### PR DESCRIPTION
A bug in the logic caused the FileMetadata.name field to be filled with `files/undefined` instead of actually being left undefined when the user does not provide that value.