### PR TITLE
Remove chat session's previous content role validation checks

### DIFF
--- a/.changeset/green-timers-behave.md
+++ b/.changeset/green-timers-behave.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Lifted a restriction in chat sessions that required a specific order of content roles.

--- a/packages/main/src/methods/chat-session-helpers.test.ts
+++ b/packages/main/src/methods/chat-session-helpers.test.ts
@@ -138,13 +138,20 @@ describe("chat-session-helpers", () => {
           { role: "user", parts: [{ text: "hi" }] },
           { role: "user", parts: [{ text: "hi" }] },
         ],
-        isValid: false,
+        isValid: true,
       },
       {
         history: [
           { role: "user", parts: [{ text: "hi" }] },
           { role: "model", parts: [{ text: "hi" }] },
           { role: "model", parts: [{ text: "hi" }] },
+        ],
+        isValid: true,
+      },
+      {
+        history: [
+          { role: "model", parts: [{ text: "hi" }] },
+          { role: "user", parts: [{ text: "hi" }] },
         ],
         isValid: false,
       },

--- a/packages/main/src/methods/chat-session-helpers.ts
+++ b/packages/main/src/methods/chat-session-helpers.ts
@@ -37,16 +37,8 @@ const VALID_PARTS_PER_ROLE: { [key in Role]: Array<keyof Part> } = {
   system: ["text"],
 };
 
-const VALID_PREVIOUS_CONTENT_ROLES: { [key in Role]: Role[] } = {
-  user: ["model"],
-  function: ["model"],
-  model: ["user", "function"],
-  // System instructions shouldn't be in history.
-  system: [],
-};
-
 export function validateChatHistory(history: Content[]): void {
-  let prevContent: Content;
+  let prevContent = false;
   for (const currContent of history) {
     const { role, parts } = currContent as { role: Role; parts: Part[] };
     if (!prevContent && role !== "user") {
@@ -98,18 +90,6 @@ export function validateChatHistory(history: Content[]): void {
       }
     }
 
-    if (prevContent) {
-      const validPreviousContentRoles = VALID_PREVIOUS_CONTENT_ROLES[role];
-      if (!validPreviousContentRoles.includes(prevContent.role as Role)) {
-        throw new GoogleGenerativeAIError(
-          `Content with role '${role}' can't follow '${
-            prevContent.role
-          }'. Valid previous roles: ${JSON.stringify(
-            VALID_PREVIOUS_CONTENT_ROLES,
-          )}`,
-        );
-      }
-    }
-    prevContent = currContent;
+    prevContent = true;
   }
 }


### PR DESCRIPTION
The service used to require chat session roles to conform to a certain pattern. This restriction has been lifted and so we shouldn't restrict it on the client-side.

Additionally update the tests around this feature.