### PR TITLE
FileState enums should be strings

### DIFF
--- a/.changeset/brave-cats-run.md
+++ b/.changeset/brave-cats-run.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fixed `FileState` enum values to be strings.

--- a/docs/reference/files/generative-ai.filestate.md
+++ b/docs/reference/files/generative-ai.filestate.md
@@ -16,8 +16,8 @@ export declare enum FileState
 
 |  Member | Value | Description |
 |  --- | --- | --- |
-|  ACTIVE | <code>2</code> |  |
-|  FAILED | <code>10</code> |  |
-|  PROCESSING | <code>1</code> |  |
-|  STATE\_UNSPECIFIED | <code>0</code> |  |
+|  ACTIVE | <code>&quot;ACTIVE&quot;</code> |  |
+|  FAILED | <code>&quot;FAILED&quot;</code> |  |
+|  PROCESSING | <code>&quot;PROCESSING&quot;</code> |  |
+|  STATE\_UNSPECIFIED | <code>&quot;STATE_UNSPECIFIED&quot;</code> |  |
 

--- a/packages/main/src/files/types.ts
+++ b/packages/main/src/files/types.ts
@@ -74,11 +74,11 @@ export interface UploadFileResponse {
  */
 export enum FileState {
   // The default value. This value is used if the state is omitted.
-  STATE_UNSPECIFIED = 0,
+  STATE_UNSPECIFIED = 'STATE_UNSPECIFIED',
   // File is being processed and cannot be used for inference yet.
-  PROCESSING = 1,
+  PROCESSING = 'PROCESSING',
   // File is processed and available for inference.
-  ACTIVE = 2,
+  ACTIVE = 'ACTIVE',
   // File failed processing.
-  FAILED = 10,
+  FAILED = 'FAILED',
 }

--- a/packages/main/src/files/types.ts
+++ b/packages/main/src/files/types.ts
@@ -74,11 +74,11 @@ export interface UploadFileResponse {
  */
 export enum FileState {
   // The default value. This value is used if the state is omitted.
-  STATE_UNSPECIFIED = 'STATE_UNSPECIFIED',
+  STATE_UNSPECIFIED = "STATE_UNSPECIFIED",
   // File is being processed and cannot be used for inference yet.
-  PROCESSING = 'PROCESSING',
+  PROCESSING = "PROCESSING",
   // File is processed and available for inference.
-  ACTIVE = 'ACTIVE',
+  ACTIVE = "ACTIVE",
   // File failed processing.
-  FAILED = 'FAILED',
+  FAILED = "FAILED",
 }


### PR DESCRIPTION
Missed converting to strings when copying over from the proto.