### PR TITLE
Fix @google/generative-ai/files paths

### DIFF
--- a/.changeset/calm-otters-confess.md
+++ b/.changeset/calm-otters-confess.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix paths to @google/generative-ai/files.

--- a/packages/main/api-extractor.files.json
+++ b/packages/main/api-extractor.files.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../config/api-extractor.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/files/src/files/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/src/files/index.d.ts",
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "<projectFolder>/dist/files/files.d.ts"

--- a/packages/main/files/package.json
+++ b/packages/main/files/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@google/generative-ai/files",
+  "name": "@google/generative-ai-files",
   "description": "GoogleAI file upload manager",
-  "main": "./dist/files/index.js",
-  "browser": "./dist/files/index.mjs",
-  "module": "./dist/files/index.mjs",
-  "typings": "./dist/files/files.d.ts"
+  "main": "../dist/files/index.js",
+  "browser": "../dist/files/index.mjs",
+  "module": "../dist/files/index.mjs",
+  "typings": "../dist/files/files.d.ts"
 }

--- a/packages/main/rollup.config.mjs
+++ b/packages/main/rollup.config.mjs
@@ -64,13 +64,17 @@ const cjsBuilds = [
 const filesBuilds = [
   {
     input: "src/files/index.ts",
-    output: [{ file: pkg.exports['./files'].import, format: "es", sourcemap: true }],
+    output: [
+      { file: pkg.exports["./files"].import, format: "es", sourcemap: true },
+    ],
     external: ["fs"],
     plugins: [...es2017BuildPlugins],
   },
   {
     input: "src/files/index.ts",
-    output: [{ file: pkg.exports['./files'].require, format: "cjs", sourcemap: true }],
+    output: [
+      { file: pkg.exports["./files"].require, format: "cjs", sourcemap: true },
+    ],
     external: ["fs"],
     plugins: [...es2017BuildPlugins],
   },

--- a/packages/main/rollup.config.mjs
+++ b/packages/main/rollup.config.mjs
@@ -20,7 +20,6 @@ import typescriptPlugin from "rollup-plugin-typescript2";
 import typescript from "typescript";
 import json from "@rollup/plugin-json";
 import pkg from "./package.json" assert { type: "json" };
-import filePkg from "./files/package.json" assert { type: "json" };
 
 const es2017BuildPlugins = [
   typescriptPlugin({
@@ -65,13 +64,13 @@ const cjsBuilds = [
 const filesBuilds = [
   {
     input: "src/files/index.ts",
-    output: [{ file: filePkg.module, format: "es", sourcemap: true }],
+    output: [{ file: pkg.exports['./files'].import, format: "es", sourcemap: true }],
     external: ["fs"],
     plugins: [...es2017BuildPlugins],
   },
   {
     input: "src/files/index.ts",
-    output: [{ file: filePkg.main, format: "cjs", sourcemap: true }],
+    output: [{ file: pkg.exports['./files'].require, format: "cjs", sourcemap: true }],
     external: ["fs"],
     plugins: [...es2017BuildPlugins],
   },


### PR DESCRIPTION
Fixes https://github.com/google-gemini/generative-ai-js/issues/155

This affects TypeScript users that are using "module: commonjs" or any other resolution that relies on the package.json in the files/ directory instead of on package.json exports.