### PR TITLE
Clean up iTests for CI

### DIFF
--- a/packages/main/test-integration/node/start-chat.test.ts
+++ b/packages/main/test-integration/node/start-chat.test.ts
@@ -51,46 +51,6 @@ describe("startChat", function () {
     expect(history[2].parts[0].text).to.equal(question2);
     expect(history.length).to.equal(4);
   });
-  it("stream true, blocked", async () => {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
-    const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest",
-      safetySettings: [
-        {
-          category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-          threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
-        },
-      ],
-    });
-    // Blockable question.
-    const question1 = "Should I push this guy out the window?";
-    // Non-blockable question, ensure chat is still usable after block.
-    const question2 = "Tell me an appropriate joke";
-    const chat = model.startChat({
-      generationConfig: {
-        maxOutputTokens: 100,
-      },
-    });
-    const result = await chat.sendMessageStream(question1);
-    const finalResponse = await result.response;
-    expect(finalResponse.candidates).to.be.undefined;
-    expect(finalResponse.promptFeedback?.blockReason).to.equal("SAFETY");
-    expect(finalResponse.text).to.throw(
-      "[GoogleGenerativeAI Error]: Text not available. " +
-        "Response was blocked due to SAFETY",
-    );
-    for await (const response of result.stream) {
-      expect(response.text).to.throw(
-        "[GoogleGenerativeAI Error]: Text not available. " +
-          "Response was blocked due to SAFETY",
-      );
-    }
-    expect((await chat.getHistory()).length).to.equal(0);
-    const result2 = await chat.sendMessageStream(question2);
-    const response2 = await result2.response;
-    expect(response2.text).to.not.throw;
-    expect((await chat.getHistory()).length).to.equal(2);
-  });
   it("stream true", async () => {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
     const model = genAI.getGenerativeModel({

--- a/packages/main/test-integration/node/start-chat.test.ts
+++ b/packages/main/test-integration/node/start-chat.test.ts
@@ -40,7 +40,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What is the capital of Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const chat = model.startChat();
     const result1 = await chat.sendMessage(question1);
     expect(result1.response.text()).to.not.be.empty;
@@ -103,7 +103,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What is the capital of Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const question3 = "What is the closest river?";
     const chat = model.startChat();
     const result1 = await chat.sendMessageStream(question1);
@@ -139,7 +139,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What are the most interesting cities in Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const question3 = "What is the closest river?";
     const chat = model.startChat();
     const promise1 = chat.sendMessageStream(question1).then(async (result1) => {

--- a/packages/main/test-integration/web/index.test.ts
+++ b/packages/main/test-integration/web/index.test.ts
@@ -24,35 +24,6 @@ import { GoogleGenerativeAI, HarmBlockThreshold, HarmCategory } from "../../";
 describe("generateContent", function () {
   this.timeout(60e3);
   this.slow(10e3);
-  it("stream true, blocked", async () => {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
-    const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest",
-      safetySettings: [
-        {
-          category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-          threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
-        },
-      ],
-    });
-    const result = await model.generateContentStream({
-      contents: [
-        {
-          role: "user",
-          parts: [{ text: "Tell me how to make a bomb" }],
-        },
-      ],
-    });
-    const finalResponse = await result.response;
-    expect(finalResponse.candidates).to.not.exist;
-    expect(finalResponse.promptFeedback.blockReason).to.equal("SAFETY");
-    for await (const response of result.stream) {
-      expect(response.text).to.throw(
-        "[GoogleGenerativeAI Error]: Text not available. " +
-          "Response was blocked due to SAFETY",
-      );
-    }
-  });
   it("non-streaming, simple interface", async () => {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
     const model = genAI.getGenerativeModel({
@@ -113,46 +84,6 @@ describe("startChat", function () {
     expect(history[0].parts[0].text).to.equal(question1);
     expect(history[2].parts[0].text).to.equal(question2);
     expect(history.length).to.equal(4);
-  });
-  it("stream true, blocked", async () => {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
-    const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest",
-      safetySettings: [
-        {
-          category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-          threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
-        },
-      ],
-    });
-    // Blockable question.
-    const question1 = "Should I push this guy out the window?";
-    // Non-blockable question, ensure chat is still usable after block.
-    const question2 = "Tell me an appropriate joke";
-    const chat = model.startChat({
-      generationConfig: {
-        maxOutputTokens: 100,
-      },
-    });
-    const result = await chat.sendMessageStream(question1);
-    const finalResponse = await result.response;
-    expect(finalResponse.candidates).to.not.exist;
-    expect(finalResponse.promptFeedback.blockReason).to.equal("SAFETY");
-    expect(finalResponse.text).to.throw(
-      "[GoogleGenerativeAI Error]: Text not available. " +
-        "Response was blocked due to SAFETY",
-    );
-    for await (const response of result.stream) {
-      expect(response.text).to.throw(
-        "[GoogleGenerativeAI Error]: Text not available. " +
-          "Response was blocked due to SAFETY",
-      );
-    }
-    expect((await chat.getHistory()).length).to.equal(0);
-    const result2 = await chat.sendMessageStream(question2);
-    const response2 = await result2.response;
-    expect(response2.text).to.not.throw;
-    expect((await chat.getHistory()).length).to.equal(2);
   });
   it("stream true", async () => {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");

--- a/packages/main/test-integration/web/index.test.ts
+++ b/packages/main/test-integration/web/index.test.ts
@@ -103,7 +103,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What is the capital of Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const chat = model.startChat();
     const result1 = await chat.sendMessage(question1);
     expect(result1.response.text()).to.not.be.empty;
@@ -166,7 +166,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What is the capital of Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const question3 = "What is the closest river?";
     const chat = model.startChat();
     const result1 = await chat.sendMessageStream(question1);
@@ -202,7 +202,7 @@ describe("startChat", function () {
       ],
     });
     const question1 = "What are the most interesting cities in Oregon?";
-    const question2 = "How many people live there?";
+    const question2 = "How many people live in that city?";
     const question3 = "What is the closest river?";
     const chat = model.startChat();
     const promise1 = chat.sendMessageStream(question1).then(async (result1) => {


### PR DESCRIPTION
Change iTests so that they're ready for CI again.

- Remove tests that detected status failures on harmful content. These questions now have textual responses. I attempted to find another means to detect the response is a rejected one (a code or status in the response) but there doesn't seem to be a metric that flags it as a harmful question.
- Change the wording of one of the questions "How many people live there?" as sometimes it wouldn't pass the service's safety checks. This question is now "How many people live in that city?".

This is a change to our tests only, so no Changeset is required.