### PR TITLE
Fix missing usageMetadata in streamed aggregated response (#174)

### DIFF
--- a/.changeset/quick-horses-retire.md
+++ b/.changeset/quick-horses-retire.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix missing usageMetadata in streamed aggregated response (#174)

--- a/packages/main/src/requests/stream-reader.ts
+++ b/packages/main/src/requests/stream-reader.ts
@@ -188,6 +188,9 @@ export function aggregateResponses(
         }
       }
     }
+    if (response.usageMetadata) {
+      aggregatedResponse.usageMetadata = response.usageMetadata;
+    }
   }
   return aggregatedResponse;
 }


### PR DESCRIPTION
Fixes https://github.com/google-gemini/generative-ai-js/issues/174