### PR TITLE
refactor: update uploadFile method to accept both file paths and Buffers

### DIFF
--- a/.changeset/dry-dodos-push.md
+++ b/.changeset/dry-dodos-push.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+the code was refactored to accept both file paths and Buffers as inputs for uploading files with metadata

--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // @public
 export interface CachedContent extends CachedContentBase {
     createTime?: string;
@@ -357,7 +359,7 @@ export class GoogleAIFileManager {
     deleteFile(fileId: string): Promise<void>;
     getFile(fileId: string): Promise<FileMetadataResponse>;
     listFiles(listParams?: ListParams): Promise<ListFilesResponse>;
-    uploadFile(filePath: string, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
+    uploadFile(fileInput: string | Buffer, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
 }
 
 // @public

--- a/docs/reference/server/generative-ai.googleaifilemanager.md
+++ b/docs/reference/server/generative-ai.googleaifilemanager.md
@@ -31,5 +31,5 @@ export declare class GoogleAIFileManager
 |  [deleteFile(fileId)](./generative-ai.googleaifilemanager.deletefile.md) |  | Delete file with given ID |
 |  [getFile(fileId)](./generative-ai.googleaifilemanager.getfile.md) |  | Get metadata for file with given ID |
 |  [listFiles(listParams)](./generative-ai.googleaifilemanager.listfiles.md) |  | List all uploaded files |
-|  [uploadFile(filePath, fileMetadata)](./generative-ai.googleaifilemanager.uploadfile.md) |  | Upload a file |
+|  [uploadFile(fileInput, fileMetadata)](./generative-ai.googleaifilemanager.uploadfile.md) |  | Upload a file |
 

--- a/docs/reference/server/generative-ai.googleaifilemanager.uploadfile.md
+++ b/docs/reference/server/generative-ai.googleaifilemanager.uploadfile.md
@@ -9,14 +9,14 @@ Upload a file
 **Signature:**
 
 ```typescript
-uploadFile(filePath: string, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
+uploadFile(fileInput: string | Buffer, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  filePath | string |  |
+|  fileInput | string \| Buffer |  |
 |  fileMetadata | [FileMetadata](./generative-ai.filemetadata.md) |  |
 
 **Returns:**

--- a/packages/main/src/server/file-manager.ts
+++ b/packages/main/src/server/file-manager.ts
@@ -51,10 +51,18 @@ export class GoogleAIFileManager {
    * Upload a file
    */
   async uploadFile(
-    filePath: string,
+    fileInput: string | Buffer,
     fileMetadata: FileMetadata,
   ): Promise<UploadFileResponse> {
-    const file = readFileSync(filePath);
+    let file: Buffer | string;
+
+    if (typeof fileInput === "string") {
+      file = readFileSync(fileInput);
+    } else if (Buffer.isBuffer(fileInput)) {
+      file = fileInput;
+    } else {
+      throw Error("fileInput must be filePath or buffer");
+    }
     const url = new FilesRequestUrl(
       RpcTask.UPLOAD,
       this.apiKey,


### PR DESCRIPTION
The code was refactored to accept both file paths and Buffers as inputs for uploading files with metadata. This change improves flexibility by eliminating synchronous file reads and allowing the in-memory ready buffer to be given to the uploadFile method instead of forcing developers to write the file locally and then read it again. 