### PR TITLE
Add import comments to all samples

### DIFF
--- a/samples/cache.js
+++ b/samples/cache.js
@@ -28,6 +28,9 @@ const mediaPath = __dirname + "/media";
 
 async function cacheCreate() {
   // [START cache_create]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
@@ -66,6 +69,9 @@ async function cacheCreate() {
 
 async function cacheCreateFromName() {
   // [START cache_create_from_name]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
@@ -102,6 +108,9 @@ async function cacheCreateFromName() {
 
 async function cacheCreateFromChat() {
   // [START cache_create_from_chat]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
@@ -147,6 +156,8 @@ async function cacheCreateFromChat() {
 
 async function cacheDelete() {
   // [START cache_delete]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
@@ -176,6 +187,8 @@ async function cacheDelete() {
 
 async function cacheGet() {
   // [START cache_get]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
@@ -207,6 +220,8 @@ async function cacheGet() {
 
 async function cacheList() {
   // [START cache_list]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
@@ -241,6 +256,8 @@ async function cacheList() {
 
 async function cacheUpdate() {
   // [START cache_update]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager, GoogleAIFileManager } from "@google/generative-ai/server";
   const cacheManager = new GoogleAICacheManager(process.env.API_KEY);
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 

--- a/samples/chat.js
+++ b/samples/chat.js
@@ -25,6 +25,8 @@ const mediaPath = __dirname + "/media";
 
 async function chat() {
   // [START chat]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
   const chat = model.startChat({
@@ -48,6 +50,8 @@ async function chat() {
 
 async function chatStreaming() {
   // [START chat_streaming]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
   const chat = model.startChat({
@@ -77,6 +81,8 @@ async function chatStreaming() {
 
 async function chatStreamingWithImages() {
   // [START chat_streaming_with_images]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
   const chat = model.startChat();

--- a/samples/code_execution.js
+++ b/samples/code_execution.js
@@ -19,6 +19,8 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 async function codeExecutionBasic() {
   // [START code_execution_basic]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -37,6 +39,8 @@ async function codeExecutionBasic() {
 
 async function codeExecutionRequestOverride() {
   // [START code_execution_request_override]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -65,6 +69,8 @@ async function codeExecutionRequestOverride() {
 
 async function codeExecutionChat() {
   // [START code_execution_chat]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",

--- a/samples/controlled_generation.js
+++ b/samples/controlled_generation.js
@@ -23,7 +23,7 @@ import {
 async function jsonControlledGeneration() {
   // [START json_controlled_generation]
   // Make sure to include these imports:
-  // import { GoogleGenerativeAI } from "@google/generative-ai";
+  // import { GoogleGenerativeAI, FunctionDeclarationSchemaType } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
 
   const schema = {

--- a/samples/controlled_generation.js
+++ b/samples/controlled_generation.js
@@ -22,6 +22,8 @@ import {
 
 async function jsonControlledGeneration() {
   // [START json_controlled_generation]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
 
   const schema = {
@@ -57,6 +59,8 @@ async function jsonControlledGeneration() {
 
 async function jsonNoSchema() {
   // [START json_no_schema]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
 
   const model = genAI.getGenerativeModel({

--- a/samples/count_tokens.js
+++ b/samples/count_tokens.js
@@ -30,6 +30,8 @@ const mediaPath = __dirname + "/media";
 
 async function tokensTextOnly() {
   // [START tokens_text_only]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -57,6 +59,8 @@ async function tokensTextOnly() {
 
 async function tokensChat() {
   // [START tokens_chat]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -70,6 +74,8 @@ async function tokensChat() {
 
 async function tokensMultimodalImageInline() {
   // [START tokens_multimodal_image_inline]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -99,6 +105,9 @@ async function tokensMultimodalImageInline() {
 
 async function tokensMultimodalImageFileApi() {
   // [START tokens_multimodal_image_file_api]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(
@@ -129,6 +138,9 @@ async function tokensMultimodalImageFileApi() {
 
 async function tokensMultimodalVideoAudioFileApi() {
   // [START tokens_multimodal_video_audio_file_api]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager, FileState } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   function waitForProcessing(fileName) {
@@ -195,6 +207,9 @@ async function tokensMultimodalVideoAudioFileApi() {
 
 async function tokensCachedContent() {
   // [START tokens_cached_content]
+  // Make sure to include these imports:
+  // import { GoogleAICacheManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   // Generate a very long string
   let longContentString = "";
   for (let i = 0; i < 32001; i++) {
@@ -235,6 +250,8 @@ async function tokensCachedContent() {
 
 async function tokensSystemInstruction() {
   // [START tokens_system_instruction]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "models/gemini-1.5-flash",
@@ -266,6 +283,8 @@ async function tokensSystemInstruction() {
 
 async function tokensTools() {
   // [START tokens_tools]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "models/gemini-1.5-flash",

--- a/samples/embed.js
+++ b/samples/embed.js
@@ -19,6 +19,8 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 async function embedContent() {
   // [START embed_content]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "text-embedding-004",
@@ -32,6 +34,8 @@ async function embedContent() {
 
 async function batchEmbedContents() {
   // [START batch_embed_contents]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "text-embedding-004",

--- a/samples/files.js
+++ b/samples/files.js
@@ -25,6 +25,9 @@ const mediaPath = __dirname + "/media";
 
 async function filesCreateImage() {
   // [START files_create_image]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(
@@ -56,6 +59,9 @@ async function filesCreateImage() {
 
 async function filesCreateAudio() {
   // [START files_create_audio]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager, FileState } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(
@@ -101,6 +107,9 @@ async function filesCreateAudio() {
 
 async function filesCreateText() {
   // [START files_create_text]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(`${mediaPath}/a11.txt`, {
@@ -129,6 +138,9 @@ async function filesCreateText() {
 
 async function filesCreateVideo() {
   // [START files_create_video]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager, FileState } from "@google/generative-ai/server";
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(
@@ -174,6 +186,8 @@ async function filesCreateVideo() {
 
 async function filesList() {
   // [START files_list]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const listFilesResponse = await fileManager.listFiles();
@@ -187,6 +201,8 @@ async function filesList() {
 
 async function filesGet() {
   // [START files_get]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResponse = await fileManager.uploadFile(
@@ -209,6 +225,8 @@ async function filesGet() {
 
 async function filesDelete() {
   // [START files_delete]
+  // Make sure to include these imports:
+  // import { GoogleAIFileManager } from "@google/generative-ai/server";
   const fileManager = new GoogleAIFileManager(process.env.API_KEY);
 
   const uploadResult = await fileManager.uploadFile(

--- a/samples/function_calling.js
+++ b/samples/function_calling.js
@@ -19,6 +19,8 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 async function functionCalling() {
   // [START function_calling]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   async function setLightValues(brightness, colorTemperature) {
     // This mock API returns the requested lighting values
     return {

--- a/samples/model_configuration.js
+++ b/samples/model_configuration.js
@@ -19,6 +19,8 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 async function configureModel() {
   // [START configure_model]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",

--- a/samples/package.json
+++ b/samples/package.json
@@ -5,6 +5,7 @@
   },
   "scripts": {
     "check-samples": "node ./utils/check-samples.js",
+    "import-comments": "node ./utils/insert-import-comments.js",
     "test": "yarn check-samples"
   }
 }

--- a/samples/safety_settings.js
+++ b/samples/safety_settings.js
@@ -23,6 +23,8 @@ import {
 
 async function safetySettings() {
   // [START safety_settings]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI, HarmBlockThreshold } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -52,6 +54,8 @@ async function safetySettings() {
 
 async function safetySettingsMulti() {
   // [START safety_settings_multi]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI, HarmBlockThreshold } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",

--- a/samples/safety_settings.js
+++ b/samples/safety_settings.js
@@ -24,7 +24,7 @@ import {
 async function safetySettings() {
   // [START safety_settings]
   // Make sure to include these imports:
-  // import { GoogleGenerativeAI, HarmBlockThreshold } from "@google/generative-ai";
+  // import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",
@@ -55,7 +55,7 @@ async function safetySettings() {
 async function safetySettingsMulti() {
   // [START safety_settings_multi]
   // Make sure to include these imports:
-  // import { GoogleGenerativeAI, HarmBlockThreshold } from "@google/generative-ai";
+  // import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",

--- a/samples/system_instruction.js
+++ b/samples/system_instruction.js
@@ -19,6 +19,8 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 async function systemInstruction() {
   // [START system_instruction]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({
     model: "gemini-1.5-flash",

--- a/samples/text_generation.js
+++ b/samples/text_generation.js
@@ -26,6 +26,8 @@ const mediaPath = __dirname + "/media";
 
 async function textGenTextOnlyPrompt() {
   // [START text_gen_text_only_prompt]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -38,6 +40,8 @@ async function textGenTextOnlyPrompt() {
 
 async function textGenTextOnlyPromptStreaming() {
   // [START text_gen_text_only_prompt_streaming]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -55,6 +59,8 @@ async function textGenTextOnlyPromptStreaming() {
 
 async function textGenMultimodalOneImagePrompt() {
   // [START text_gen_multimodal_one_image_prompt]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -81,6 +87,8 @@ async function textGenMultimodalOneImagePrompt() {
 
 async function textGenMultimodalOneImagePromptStreaming() {
   // [START text_gen_multimodal_one_image_prompt_streaming]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -112,6 +120,8 @@ async function textGenMultimodalOneImagePromptStreaming() {
 
 async function textGenMultimodalMultiImagePrompt() {
   // [START text_gen_multimodal_multi_image_prompt]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -142,6 +152,8 @@ async function textGenMultimodalMultiImagePrompt() {
 
 async function textGenMultimodalMultiImagePromptStreaming() {
   // [START text_gen_multimodal_multi_image_prompt_streaming]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -177,6 +189,8 @@ async function textGenMultimodalMultiImagePromptStreaming() {
 
 async function textGenMultimodalAudio() {
   // [START text_gen_multimodal_audio]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -203,6 +217,9 @@ async function textGenMultimodalAudio() {
 
 async function textGenMultimodalVideoPrompt() {
   // [START text_gen_multimodal_video_prompt]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
+  // import { GoogleAIFileManager, FileState } from "@google/generative-ai/server";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
@@ -242,6 +259,9 @@ async function textGenMultimodalVideoPrompt() {
 
 async function textGenMultimodalVideoPromptStreaming() {
   // [START text_gen_multimodal_video_prompt_streaming]
+  // Make sure to include these imports:
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
+  // import { GoogleAIFileManager, FileState } from "@google/generative-ai/server";
   const genAI = new GoogleGenerativeAI(process.env.API_KEY);
   const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 

--- a/samples/utils/common.js
+++ b/samples/utils/common.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const samplesDir = join(__dirname, "../");
+
+/**
+ * Extracts individual function information, given the text of a samples file.
+ */
+export function findFunctions(fileText) {
+  const lines = fileText.split("\n");
+  const functions = {};
+  let currentFunctionName = "";
+  for (const [index, line] of lines.entries()) {
+    const functionStartParts = line.match(/^(async function|function) (.+)\(/);
+    if (functionStartParts) {
+      currentFunctionName = functionStartParts[2];
+      functions[currentFunctionName] = { body: [] };
+    } else if (line.match(/^}$/)) {
+      currentFunctionName = "";
+    } else if (currentFunctionName) {
+      const tagStartParts = line.match(/\/\/ \[START (.+)\]/);
+      const tagEndParts = line.match(/\/\/ \[END (.+)\]/);
+      const importHead = line.match(/\/\/ Make sure to include/);
+      const importComment = line.match(/\/\/ import /);
+      if (tagStartParts) {
+        functions[currentFunctionName].startTag = {
+          line: index,
+          tag: tagStartParts[1],
+        };
+      } else if (tagEndParts) {
+        functions[currentFunctionName].endTag = {
+          line: index,
+          tag: tagEndParts[1],
+        };
+      } else if (importHead || importComment) {
+        if (!functions[currentFunctionName].importComments) {
+          functions[currentFunctionName].importComments = [];
+        }
+        functions[currentFunctionName].importComments.push(line);
+      } else {
+        functions[currentFunctionName].body.push(line);
+      }
+    }
+  }
+  return functions;
+}

--- a/samples/utils/insert-import-comments.js
+++ b/samples/utils/insert-import-comments.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findFunctions, samplesDir } from "./common.js";
+import fs from "fs";
+import { join } from "path";
+
+const requiredImports = [
+  {
+    importPath: "@google/generative-ai",
+    symbols: ["GoogleGenerativeAI", "HarmBlockThreshold", "HarmBlockCategory"],
+  },
+  {
+    importPath: "@google/generative-ai/server",
+    symbols: ["GoogleAIFileManager", "GoogleAICacheManager", "FileState"],
+  },
+];
+
+function listRequiredImports(line) {
+  const results = [];
+  for (const requiredImport of requiredImports) {
+    for (const symbol of requiredImport.symbols) {
+      if (line.includes(symbol)) {
+        if (!results[requiredImport.importPath]) {
+          results[requiredImport.importPath] = [];
+        }
+        results[requiredImport.importPath].push(symbol);
+        results.push({ symbol, importPath: requiredImport.importPath });
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Inserts comments describing the required imports for making the code
+ * sample work, since we cannot add actual import statements inside
+ * the samples.
+ */
+async function insertImportComments() {
+  const files = fs.readdirSync(samplesDir);
+  for (const filename of files) {
+    if (filename.match(/.+\.js$/) && !filename.includes("-")) {
+      const file = fs.readFileSync(join(samplesDir, filename), "utf-8");
+      const functions = findFunctions(file);
+      for (const fnName in functions) {
+        const sampleFn = functions[fnName];
+        let results = [];
+        for (const line of sampleFn.body) {
+          results = results.concat(listRequiredImports(line));
+        }
+        if (results.length > 0) {
+          functions[fnName].requiredImports = {};
+          for (const result of results) {
+            if (!functions[fnName].requiredImports[result.importPath]) {
+              functions[fnName].requiredImports[result.importPath] = new Set();
+            }
+            functions[fnName].requiredImports[result.importPath].add(
+              result.symbol,
+            );
+          }
+        }
+      }
+      const fileLines = file.split("\n");
+      const newFileLines = [];
+      for (const fileLine of fileLines) {
+        const importHead = fileLine.match(/\/\/ Make sure to include/);
+        const importComment = fileLine.match(/\/\/ import /);
+        if (!importHead && !importComment) {
+          newFileLines.push(fileLine);
+        }
+        const tagStartParts = fileLine.match(/\/\/ \[START (.+)\]/);
+        if (tagStartParts) {
+          const fnName = underscoreToCamelCase(tagStartParts[1]);
+          if (functions[fnName].requiredImports) {
+            newFileLines.push(`  // Make sure to include these imports:`);
+            for (const importPath in functions[fnName].requiredImports) {
+              const symbols = Array.from(
+                functions[fnName].requiredImports[importPath],
+              );
+              newFileLines.push(
+                `  // import { ${symbols.join(", ")} } from "${importPath}";`,
+              );
+            }
+          }
+        }
+      }
+      fs.writeFileSync(join(samplesDir, filename), newFileLines.join("\n"));
+    }
+  }
+}
+
+function underscoreToCamelCase(underscoreName) {
+  return underscoreName
+    .split("_")
+    .map((part, i) =>
+      i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join("");
+}
+
+insertImportComments();


### PR DESCRIPTION
ESM requires import statements to only occur once, at the top of each file. Since we have multiple samples in each file, we use comments to indicate to users which imports are needed for each sample, and what the import statements should be.

I wrote a script (`insert-import-comments.js`) to parse each sample and identify which symbols it needs to import, and from which path, and add the comments, and ran the script.

I also abstracted the code that parses function info and shared it between the new script and the check-samples.js script.