### PR TITLE
Fix count tokens to include model params

### DIFF
--- a/.changeset/rare-birds-bow.md
+++ b/.changeset/rare-birds-bow.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix countTokens to include any params set on the model instance.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@web/test-runner": "^0.18.0",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
+    "chai-deep-equal-ignore-undefined": "^1.1.1",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-unused-imports": "^3.0.0",

--- a/packages/main/src/models/generative-model.test.ts
+++ b/packages/main/src/models/generative-model.test.ts
@@ -240,6 +240,7 @@ describe("GenerativeModel", () => {
       "apiKey",
       {
         model: "my-model",
+        systemInstruction: "you are a cat",
       },
       {
         apiVersion: "v2000",
@@ -257,7 +258,9 @@ describe("GenerativeModel", () => {
       request.Task.COUNT_TOKENS,
       match.any,
       false,
-      match.any,
+      match((value: string) => {
+        return value.includes("hello") && value.includes("you are a cat");
+      }),
       match((value) => {
         return value.apiVersion === "v2000";
       }),

--- a/packages/main/src/models/generative-model.ts
+++ b/packages/main/src/models/generative-model.ts
@@ -164,7 +164,15 @@ export class GenerativeModel {
   async countTokens(
     request: CountTokensRequest | string | Array<string | Part>,
   ): Promise<CountTokensResponse> {
-    const formattedParams = formatCountTokensInput(request, this.model);
+    const formattedParams = formatCountTokensInput(request, {
+      model: this.model,
+      generationConfig: this.generationConfig,
+      safetySettings: this.safetySettings,
+      tools: this.tools,
+      toolConfig: this.toolConfig,
+      systemInstruction: this.systemInstruction,
+      cachedContent: this.cachedContent,
+    });
     return countTokens(
       this.apiKey,
       this.model,

--- a/packages/main/src/requests/request-helpers.test.ts
+++ b/packages/main/src/requests/request-helpers.test.ts
@@ -17,10 +17,15 @@
 
 import { expect, use } from "chai";
 import * as sinonChai from "sinon-chai";
+import chaiDeepEqualIgnoreUndefined from "chai-deep-equal-ignore-undefined";
 import { Content } from "../../types";
-import { formatGenerateContentInput } from "./request-helpers";
+import {
+  formatCountTokensInput,
+  formatGenerateContentInput,
+} from "./request-helpers";
 
 use(sinonChai);
+use(chaiDeepEqualIgnoreUndefined);
 
 describe("request formatting methods", () => {
   describe("formatGenerateContentInput", () => {
@@ -169,6 +174,106 @@ describe("request formatting methods", () => {
           },
         ],
         systemInstruction: { role: "system", parts: [{ text: "be excited" }] },
+      });
+    });
+  });
+  describe("formatCountTokensInput", () => {
+    it("formats a text string into a count request", () => {
+      const result = formatCountTokensInput("some text content", {
+        model: "gemini-1.5-flash",
+      });
+      // expect(result.generateContentRequest.model).to.equal("gemini-1.5-flash");
+      // expect(result.generateContentRequest.contents).to.equal("gemini-1.5-flash");
+      expect(result.generateContentRequest).to.deepEqualIgnoreUndefined({
+        model: "gemini-1.5-flash",
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "some text content" }],
+          },
+        ],
+      });
+    });
+    it("formats a text string into a count request, along with model params", () => {
+      const result = formatCountTokensInput("some text content", {
+        model: "gemini-1.5-flash",
+        systemInstruction: "hello",
+        tools: [{ codeExecution: {} }],
+        cachedContent: { name: "mycache", contents: [] },
+      });
+      expect(result.generateContentRequest).to.deepEqualIgnoreUndefined({
+        model: "gemini-1.5-flash",
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "some text content" }],
+          },
+        ],
+        systemInstruction: "hello",
+        tools: [{ codeExecution: {} }],
+        cachedContent: "mycache",
+      });
+    });
+    it("formats a 'contents' style count request, along with model params", () => {
+      const result = formatCountTokensInput(
+        {
+          contents: [
+            {
+              role: "user",
+              parts: [{ text: "some text content" }],
+            },
+          ],
+        },
+        {
+          model: "gemini-1.5-flash",
+          systemInstruction: "hello",
+          tools: [{ codeExecution: {} }],
+          cachedContent: { name: "mycache", contents: [] },
+        },
+      );
+      expect(result.generateContentRequest).to.deepEqualIgnoreUndefined({
+        model: "gemini-1.5-flash",
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "some text content" }],
+          },
+        ],
+        systemInstruction: "hello",
+        tools: [{ codeExecution: {} }],
+        cachedContent: "mycache",
+      });
+    });
+    it("formats a 'generateContentRequest' style count request, along with model params", () => {
+      const result = formatCountTokensInput(
+        {
+          generateContentRequest: {
+            contents: [
+              {
+                role: "user",
+                parts: [{ text: "some text content" }],
+              },
+            ],
+          },
+        },
+        {
+          model: "gemini-1.5-flash",
+          systemInstruction: "hello",
+          tools: [{ codeExecution: {} }],
+          cachedContent: { name: "mycache", contents: [] },
+        },
+      );
+      expect(result.generateContentRequest).to.deepEqualIgnoreUndefined({
+        model: "gemini-1.5-flash",
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "some text content" }],
+          },
+        ],
+        systemInstruction: "hello",
+        tools: [{ codeExecution: {} }],
+        cachedContent: "mycache",
       });
     });
   });

--- a/packages/main/src/requests/request-helpers.test.ts
+++ b/packages/main/src/requests/request-helpers.test.ts
@@ -182,8 +182,6 @@ describe("request formatting methods", () => {
       const result = formatCountTokensInput("some text content", {
         model: "gemini-1.5-flash",
       });
-      // expect(result.generateContentRequest.model).to.equal("gemini-1.5-flash");
-      // expect(result.generateContentRequest.contents).to.equal("gemini-1.5-flash");
       expect(result.generateContentRequest).to.deepEqualIgnoreUndefined({
         model: "gemini-1.5-flash",
         contents: [

--- a/packages/main/src/requests/request-helpers.ts
+++ b/packages/main/src/requests/request-helpers.ts
@@ -125,18 +125,6 @@ export function formatCountTokensInput(
     cachedContent: modelParams?.cachedContent?.name,
     contents: [],
   };
-  // let formattedRequest: _CountTokensRequestInternal = {
-  //   generateContentRequest: {
-  //     model: modelParams?.model,
-  //     generationConfig: modelParams?.generationConfig,
-  //     safetySettings: modelParams?.safetySettings,
-  //     tools: modelParams?.tools,
-  //     toolConfig: modelParams?.toolConfig,
-  //     systemInstruction: modelParams?.systemInstruction,
-  //     cachedContent: modelParams?.cachedContent?.name,
-  //     contents: [],
-  //   },
-  // };
   const containsGenerateContentRequest =
     (params as CountTokensRequest).generateContentRequest != null;
   if ((params as CountTokensRequest).contents) {

--- a/packages/main/src/requests/request-helpers.ts
+++ b/packages/main/src/requests/request-helpers.ts
@@ -20,8 +20,10 @@ import {
   CountTokensRequest,
   EmbedContentRequest,
   GenerateContentRequest,
+  ModelParams,
   Part,
   _CountTokensRequestInternal,
+  _GenerateContentRequestInternal,
 } from "../../types";
 import {
   GoogleGenerativeAIError,
@@ -111,9 +113,30 @@ function assignRoleToPartsAndValidateSendMessageRequest(
 
 export function formatCountTokensInput(
   params: CountTokensRequest | string | Array<string | Part>,
-  model: string,
+  modelParams?: ModelParams,
 ): _CountTokensRequestInternal {
-  let formattedRequest: _CountTokensRequestInternal = {};
+  let formattedGenerateContentRequest: _GenerateContentRequestInternal = {
+    model: modelParams?.model,
+    generationConfig: modelParams?.generationConfig,
+    safetySettings: modelParams?.safetySettings,
+    tools: modelParams?.tools,
+    toolConfig: modelParams?.toolConfig,
+    systemInstruction: modelParams?.systemInstruction,
+    cachedContent: modelParams?.cachedContent?.name,
+    contents: [],
+  };
+  // let formattedRequest: _CountTokensRequestInternal = {
+  //   generateContentRequest: {
+  //     model: modelParams?.model,
+  //     generationConfig: modelParams?.generationConfig,
+  //     safetySettings: modelParams?.safetySettings,
+  //     tools: modelParams?.tools,
+  //     toolConfig: modelParams?.toolConfig,
+  //     systemInstruction: modelParams?.systemInstruction,
+  //     cachedContent: modelParams?.cachedContent?.name,
+  //     contents: [],
+  //   },
+  // };
   const containsGenerateContentRequest =
     (params as CountTokensRequest).generateContentRequest != null;
   if ((params as CountTokensRequest).contents) {
@@ -122,16 +145,20 @@ export function formatCountTokensInput(
         "CountTokensRequest must have one of contents or generateContentRequest, not both.",
       );
     }
-    formattedRequest = { ...(params as CountTokensRequest) };
+    formattedGenerateContentRequest.contents = (
+      params as CountTokensRequest
+    ).contents;
   } else if (containsGenerateContentRequest) {
-    formattedRequest = { ...(params as CountTokensRequest) };
-    formattedRequest.generateContentRequest.model = model;
+    formattedGenerateContentRequest = {
+      ...formattedGenerateContentRequest,
+      ...(params as CountTokensRequest).generateContentRequest,
+    };
   } else {
     // Array or string
     const content = formatNewContent(params as string | Array<string | Part>);
-    formattedRequest.contents = [content];
+    formattedGenerateContentRequest.contents = [content];
   }
-  return formattedRequest;
+  return { generateContentRequest: formattedGenerateContentRequest };
 }
 
 export function formatGenerateContentInput(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,6 +2389,11 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
+chai-deep-equal-ignore-undefined@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chai-deep-equal-ignore-undefined/-/chai-deep-equal-ignore-undefined-1.1.1.tgz#c9e3736fed06c83572f03c592c025cf2703fd1a1"
+  integrity sha512-BE4nUR2Jbqmmv8A0EuAydFRB/lXgXWAfa9TvO3YzHeGHAU7ZRwPZyu074oDl/CZtNXM7jXINpQxKBOe7N0P4bg==
+
 chai@^4.3.10:
   version "4.3.10"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.10.tgz#d784cec635e3b7e2ffb66446a63b4e33bd390384"


### PR DESCRIPTION
Count tokens request should include any params set on the model parent class, including systemInstruction, tools, cachedContent.

Updated samples to use this.

generationConfig, toolConfig, and safetySettings don't seem like they would affect tokenCount but might as well pass them through, as they are part of a complete GenerateContentRequest and may affect tokenCount in the future.