### PR TITLE
Fix caution alert in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ build with the Gemini API. The Gemini API gives you access to Gemini
 Gemini models are built from the ground up to be multimodal, so you can reason
 seamlessly across text, images, and code.
 
-> [!CAUTION] **Using the Google AI SDK for JavaScript directly from a
-> client-side app is recommended for prototyping only.** If you plan to enable
-> billing, we strongly recommend that you call the Google AI Gemini API only
-> server-side to keep your API key safe. You risk potentially exposing your API
-> key to malicious actors if you embed your API key directly in your JavaScript
-> app or fetch it remotely at runtime.
+> [!CAUTION]
+> **Using the Google AI SDK for JavaScript directly from a client-side app is
+> recommended for prototyping only.** If you plan to enable billing, we strongly
+> recommend that you call the Google AI Gemini API only server-side to keep your
+> API key safe. You risk potentially exposing your API key to malicious actors
+> if you embed your API key directly in your JavaScript app or fetch it remotely
+> at runtime.
 
 ## Get started with the Gemini API
 


### PR DESCRIPTION
Markdown [alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) (e.g., `[!CAUTION]`) need to be placed on their own line to be rendered correctly. Similar fix in https://github.com/google-gemini/generative-ai-swift/pull/197.