### PR TITLE
Use lowercase SchemaType enum values

### DIFF
--- a/.changeset/warm-mails-grab.md
+++ b/.changeset/warm-mails-grab.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": minor
+---
+
+Use lowercase SchemaType enum values to match json-schema.

--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -440,12 +440,12 @@ export interface Schema {
 
 // @public
 export enum SchemaType {
-    ARRAY = "ARRAY",
-    BOOLEAN = "BOOLEAN",
-    INTEGER = "INTEGER",
-    NUMBER = "NUMBER",
-    OBJECT = "OBJECT",
-    STRING = "STRING"
+    ARRAY = "array",
+    BOOLEAN = "boolean",
+    INTEGER = "integer",
+    NUMBER = "number",
+    OBJECT = "object",
+    STRING = "string"
 }
 
 // @public

--- a/common/api-review/generative-ai.api.md
+++ b/common/api-review/generative-ai.api.md
@@ -655,12 +655,12 @@ export interface Schema {
 
 // @public
 export enum SchemaType {
-    ARRAY = "ARRAY",
-    BOOLEAN = "BOOLEAN",
-    INTEGER = "INTEGER",
-    NUMBER = "NUMBER",
-    OBJECT = "OBJECT",
-    STRING = "STRING"
+    ARRAY = "array",
+    BOOLEAN = "boolean",
+    INTEGER = "integer",
+    NUMBER = "number",
+    OBJECT = "object",
+    STRING = "string"
 }
 
 // @public

--- a/docs/reference/main/generative-ai.schematype.md
+++ b/docs/reference/main/generative-ai.schematype.md
@@ -16,10 +16,10 @@ export declare enum SchemaType
 
 |  Member | Value | Description |
 |  --- | --- | --- |
-|  ARRAY | <code>&quot;ARRAY&quot;</code> | Array type. |
-|  BOOLEAN | <code>&quot;BOOLEAN&quot;</code> | Boolean type. |
-|  INTEGER | <code>&quot;INTEGER&quot;</code> | Integer type. |
-|  NUMBER | <code>&quot;NUMBER&quot;</code> | Number type. |
-|  OBJECT | <code>&quot;OBJECT&quot;</code> | Object type. |
-|  STRING | <code>&quot;STRING&quot;</code> | String type. |
+|  ARRAY | <code>&quot;array&quot;</code> | Array type. |
+|  BOOLEAN | <code>&quot;boolean&quot;</code> | Boolean type. |
+|  INTEGER | <code>&quot;integer&quot;</code> | Integer type. |
+|  NUMBER | <code>&quot;number&quot;</code> | Number type. |
+|  OBJECT | <code>&quot;object&quot;</code> | Object type. |
+|  STRING | <code>&quot;string&quot;</code> | String type. |
 

--- a/docs/reference/server/generative-ai.schematype.md
+++ b/docs/reference/server/generative-ai.schematype.md
@@ -16,10 +16,10 @@ export declare enum SchemaType
 
 |  Member | Value | Description |
 |  --- | --- | --- |
-|  ARRAY | <code>&quot;ARRAY&quot;</code> | Array type. |
-|  BOOLEAN | <code>&quot;BOOLEAN&quot;</code> | Boolean type. |
-|  INTEGER | <code>&quot;INTEGER&quot;</code> | Integer type. |
-|  NUMBER | <code>&quot;NUMBER&quot;</code> | Number type. |
-|  OBJECT | <code>&quot;OBJECT&quot;</code> | Object type. |
-|  STRING | <code>&quot;STRING&quot;</code> | String type. |
+|  ARRAY | <code>&quot;array&quot;</code> | Array type. |
+|  BOOLEAN | <code>&quot;boolean&quot;</code> | Boolean type. |
+|  INTEGER | <code>&quot;integer&quot;</code> | Integer type. |
+|  NUMBER | <code>&quot;number&quot;</code> | Number type. |
+|  OBJECT | <code>&quot;object&quot;</code> | Object type. |
+|  STRING | <code>&quot;string&quot;</code> | String type. |
 

--- a/types/function-calling.ts
+++ b/types/function-calling.ts
@@ -86,17 +86,17 @@ export declare interface FunctionDeclarationsTool {
  */
 export enum SchemaType {
   /** String type. */
-  STRING = "STRING",
+  STRING = "string",
   /** Number type. */
-  NUMBER = "NUMBER",
+  NUMBER = "number",
   /** Integer type. */
-  INTEGER = "INTEGER",
+  INTEGER = "integer",
   /** Boolean type. */
-  BOOLEAN = "BOOLEAN",
+  BOOLEAN = "boolean",
   /** Array type. */
-  ARRAY = "ARRAY",
+  ARRAY = "array",
   /** Object type. */
-  OBJECT = "OBJECT",
+  OBJECT = "object",
 }
 
 /**


### PR DESCRIPTION
This fixes the serialized values of the `SchemaType` enum to follow [the swagger doc referenced in comments](https://swagger.io/docs/specification/data-models/data-types/), and [the json-schema spec](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1) upon which the swagger spec is based.

This change makes this package compatible with the myriad other tools (like [AJV](https://ajv.js.org/guide/typescript.html)) that allow the definition of validators, types, etc using standard json-schema.

I've tested sending lowercased values to gemini, and this appears to work perfectly, despite the TypeScript errors that this PR resolves.