### PR TITLE
Add condition to skip test if secrets not available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
       run: yarn test
 
   node-integration-test:
+    if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -63,6 +64,7 @@ jobs:
       run: yarn test:node:integration
 
   web-integration-test:
+    if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Integration tests depend on API key secret - this is not available if run from an outside contributor or fork.

I'll also need to make the checks non-required. It'll be up to the maintainer to check them before approving.