### PR TITLE
Stop hardcoding "python" in text convenience method that returns code execution markdown

### DIFF
--- a/.changeset/gorgeous-squids-wonder.md
+++ b/.changeset/gorgeous-squids-wonder.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix language marker in text helper for executable code results.

--- a/src/requests/response-helpers.ts
+++ b/src/requests/response-helpers.ts
@@ -125,7 +125,11 @@ export function getText(response: GenerateContentResponse): string {
       }
       if (part.executableCode) {
         textStrings.push(
-          "\n```python\n" + part.executableCode.code + "\n```\n",
+          "\n```" +
+            part.executableCode.language +
+            "\n" +
+            part.executableCode.code +
+            "\n```\n",
         );
       }
       if (part.codeExecutionResult) {


### PR DESCRIPTION
Python is currently the only language the code execution feature will return but we still shouldn't hardcode it. The language is a response property for a reason.