### PR TITLE
Update changelog to include 0.16.1 patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 
 ## 0.16.1
 
-This is a cherry-picked patch to fix an bug for users pinned to
-versions 0.16.x.
+This is a cherry-picked patch to fix an bug for users pinned to versions 0.16.x.
 
 ### Patch Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Minor Changes
 
-- 3b5daae: Fix `Schema` type to reference itself and not a derived type in its `items` array and `properties` map.## 0.16.1
+- 3b5daae: Fix `Schema` type to reference itself and not a derived type in its `items` array and `properties` map.
 
 ## 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@
 
 ### Minor Changes
 
-- 3b5daae: Fix `Schema` type to reference itself and not a derived type in its `items` array and `properties` map.
+- 3b5daae: Fix `Schema` type to reference itself and not a derived type in its `items` array and `properties` map.## 0.16.1
+
+## 0.16.1
+
+This is a cherry-picked patch to fix an bug for users pinned to
+versions 0.16.x.
+
+### Patch Changes
+
+- fdfb5bd: Fix reference to `requestOptions` in `startChat`.
 
 ## 0.16.0
 


### PR DESCRIPTION
Cherry-picked a fix from 0.17.1 into 0.16.0 to fix a bug for GenKit users and other users pinned to 0.16.x - the resulting release is 0.16.1. The NPM and GitHub releases are already done, just adding a changelog entry.