### PR TITLE
Fix FunctionDeclarationSchema type not allowing strings

### DIFF
--- a/types/function-calling.ts
+++ b/types/function-calling.ts
@@ -135,7 +135,7 @@ export interface Schema {
  */
 export interface FunctionDeclarationSchema {
   /** The type of the parameter. */
-  type: SchemaType;
+  type: SchemaType | `${SchemaType}`;
   /** The format of the parameter. */
   properties: { [k: string]: FunctionDeclarationSchemaProperty };
   /** Optional. Description of the parameter. */


### PR DESCRIPTION
If I use [Google's AI Studio](https://aistudio.google.com/) and edit my functions. It will give me an object like this:

```
[
  {
    "name": "getWeather",
    "description": "get the weather for a location",
    "parameters": {
      "type": "object",
      "properties": {
        "location": {
          "type": "string"
        }
      }
    }
  }
]
```

TypeScript will throw an error for this because I used `"object"` instead of `SchemaType.OBJECT` for  `"type"`. It will however work fine in Javascript.

This pull request simply allows `FunctionDeclarationSchema` to accept any value from the `SchemaType` enum or its string equivalent. 
```
type: "string" | "number" | "boolean" | "object" | SchemaType | "integer" | "array"
```