### PR TITLE
Fix the issue #124

### DIFF
--- a/src/methods/chat-session.test.ts
+++ b/src/methods/chat-session.test.ts
@@ -22,6 +22,8 @@ import * as chaiAsPromised from "chai-as-promised";
 import * as generateContentMethods from "./generate-content";
 import { GenerateContentStreamResult } from "../../types";
 import { ChatSession } from "./chat-session";
+import { getMockResponse } from "../../test-utils/mock-response";
+import * as request from "../requests/request";
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -43,6 +45,15 @@ describe("ChatSession", () => {
         "a-model",
         match.any,
       );
+    });
+  });
+  describe("sendMessageRecitationErrorNotAddingResponseToHistory()", () => {
+    it("generateContent errors should be catchable", async () => {
+      const mockResponse = getMockResponse("unary-failure-citations.json");
+      stub(request, "makeModelRequest").resolves(mockResponse as Response);
+      const chatSession = new ChatSession("MY_API_KEY", "a-model");
+      await chatSession.sendMessage("hello");
+      expect((await chatSession.getHistory()).length).equals(0);
     });
   });
   describe("sendMessageStream()", () => {

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -110,7 +110,8 @@ export class ChatSession {
       .then((result) => {
         if (
           result.response.candidates &&
-          result.response.candidates.length > 0
+          result.response.candidates.length > 0 &&
+          result.response.candidates[0]?.content !== undefined
         ) {
           this._history.push(newContent);
           const responseContent: Content = {
@@ -179,7 +180,11 @@ export class ChatSession {
       })
       .then((streamResult) => streamResult.response)
       .then((response) => {
-        if (response.candidates && response.candidates.length > 0) {
+        if (
+          response.candidates &&
+          response.candidates.length > 0 &&
+          response.candidates[0]?.content !== undefined
+        ) {
           this._history.push(newContent);
           const responseContent = { ...response.candidates[0].content };
           // Response seems to come back without a role set.

--- a/test-utils/mock-responses/unary-failure-citations.json
+++ b/test-utils/mock-responses/unary-failure-citations.json
@@ -1,0 +1,13 @@
+{
+    "candidates": [
+        {
+            "finishReason": "RECITATION",
+            "index": 0
+        }
+    ],
+    "usageMetadata": {
+        "promptTokenCount": 18,
+        "totalTokenCount": 18
+    },
+    "modelVersion": "gemini-1.5-flash-001"
+}


### PR DESCRIPTION
When chat is blocked by citation error, the content will be empty.  However the empty content will be added to the chat history.  This will cause the chat error when the chat session try to send a new message. Because the backend will always complain model content has empty parts.