### PR TITLE
Feat/add buffer support

### DIFF
--- a/.changeset/fuzzy-cows-approve.md
+++ b/.changeset/fuzzy-cows-approve.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": minor
+---
+
+added support for buffers in uploadFile

--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // @public
 export interface CachedContent extends CachedContentBase {
     createTime?: string;
@@ -347,7 +349,7 @@ export class GoogleAIFileManager {
     deleteFile(fileId: string): Promise<void>;
     getFile(fileId: string, requestOptions?: SingleRequestOptions): Promise<FileMetadataResponse>;
     listFiles(listParams?: ListParams, requestOptions?: SingleRequestOptions): Promise<ListFilesResponse>;
-    uploadFile(filePath: string, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
+    uploadFile(fileData: string | Buffer, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
 }
 
 // @public

--- a/docs/reference/server/generative-ai.googleaifilemanager.md
+++ b/docs/reference/server/generative-ai.googleaifilemanager.md
@@ -31,5 +31,5 @@ export declare class GoogleAIFileManager
 |  [deleteFile(fileId)](./generative-ai.googleaifilemanager.deletefile.md) |  | Delete file with given ID. |
 |  [getFile(fileId, requestOptions)](./generative-ai.googleaifilemanager.getfile.md) |  | <p>Get metadata for file with given ID.</p><p>Any fields set in the optional [SingleRequestOptions](./generative-ai.singlerequestoptions.md) parameter will take precedence over the [RequestOptions](./generative-ai.requestoptions.md) values provided at the time of the [GoogleAIFileManager](./generative-ai.googleaifilemanager.md) initialization.</p> |
 |  [listFiles(listParams, requestOptions)](./generative-ai.googleaifilemanager.listfiles.md) |  | <p>List all uploaded files.</p><p>Any fields set in the optional [SingleRequestOptions](./generative-ai.singlerequestoptions.md) parameter will take precedence over the [RequestOptions](./generative-ai.requestoptions.md) values provided at the time of the [GoogleAIFileManager](./generative-ai.googleaifilemanager.md) initialization.</p> |
-|  [uploadFile(filePath, fileMetadata)](./generative-ai.googleaifilemanager.uploadfile.md) |  | Upload a file. |
+|  [uploadFile(fileData, fileMetadata)](./generative-ai.googleaifilemanager.uploadfile.md) |  | Upload a file. |
 

--- a/docs/reference/server/generative-ai.googleaifilemanager.uploadfile.md
+++ b/docs/reference/server/generative-ai.googleaifilemanager.uploadfile.md
@@ -9,14 +9,14 @@ Upload a file.
 **Signature:**
 
 ```typescript
-uploadFile(filePath: string, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
+uploadFile(fileData: string | Buffer, fileMetadata: FileMetadata): Promise<UploadFileResponse>;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  filePath | string |  |
+|  fileData | string \| Buffer |  |
 |  fileMetadata | [FileMetadata](./generative-ai.filemetadata.md) |  |
 
 **Returns:**

--- a/src/server/file-manager.ts
+++ b/src/server/file-manager.ts
@@ -51,10 +51,11 @@ export class GoogleAIFileManager {
    * Upload a file.
    */
   async uploadFile(
-    filePath: string,
+    fileData: string | Buffer,
     fileMetadata: FileMetadata,
   ): Promise<UploadFileResponse> {
-    const file = readFileSync(filePath);
+    const file = fileData instanceof Buffer ? fileData : readFileSync(fileData);
+
     const url = new FilesRequestUrl(
       RpcTask.UPLOAD,
       this.apiKey,


### PR DESCRIPTION
This Pull-Request adds support for using `Buffer` inside of `uploadFile` function instead of having file to be on local disk. It can be used for example to process a form request and upload immediately instead of saving it on local and then uploading it.