### PR TITLE
Fix the issues #310 and #309

### DIFF
--- a/.changeset/flat-gorillas-happen.md
+++ b/.changeset/flat-gorillas-happen.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix undefined candidate index

--- a/.changeset/flat-gorillas-happen.md
+++ b/.changeset/flat-gorillas-happen.md
@@ -2,4 +2,4 @@
 "@google/generative-ai": patch
 ---
 
-Fix undefined candidate index
+Fix undefined candidate index.

--- a/src/requests/stream-reader.ts
+++ b/src/requests/stream-reader.ts
@@ -140,25 +140,26 @@ export function aggregateResponses(
   };
   for (const response of responses) {
     if (response.candidates) {
+      let candidateIndex = 0;
       for (const candidate of response.candidates) {
-        const i = candidate.index;
         if (!aggregatedResponse.candidates) {
           aggregatedResponse.candidates = [];
         }
-        if (!aggregatedResponse.candidates[i]) {
-          aggregatedResponse.candidates[i] = {
-            index: candidate.index,
+        if (!aggregatedResponse.candidates[candidateIndex]) {
+          aggregatedResponse.candidates[candidateIndex] = {
+            index: candidateIndex,
           } as GenerateContentCandidate;
         }
         // Keep overwriting, the last one will be final
-        aggregatedResponse.candidates[i].citationMetadata =
+        aggregatedResponse.candidates[candidateIndex].citationMetadata =
           candidate.citationMetadata;
-        aggregatedResponse.candidates[i].groundingMetadata =
+        aggregatedResponse.candidates[candidateIndex].groundingMetadata =
           candidate.groundingMetadata;
-        aggregatedResponse.candidates[i].finishReason = candidate.finishReason;
-        aggregatedResponse.candidates[i].finishMessage =
+        aggregatedResponse.candidates[candidateIndex].finishReason =
+          candidate.finishReason;
+        aggregatedResponse.candidates[candidateIndex].finishMessage =
           candidate.finishMessage;
-        aggregatedResponse.candidates[i].safetyRatings =
+        aggregatedResponse.candidates[candidateIndex].safetyRatings =
           candidate.safetyRatings;
 
         /**
@@ -166,8 +167,8 @@ export function aggregateResponses(
          * possible malformed responses.
          */
         if (candidate.content && candidate.content.parts) {
-          if (!aggregatedResponse.candidates[i].content) {
-            aggregatedResponse.candidates[i].content = {
+          if (!aggregatedResponse.candidates[candidateIndex].content) {
+            aggregatedResponse.candidates[candidateIndex].content = {
               role: candidate.content.role || "user",
               parts: [],
             };
@@ -189,12 +190,13 @@ export function aggregateResponses(
             if (Object.keys(newPart).length === 0) {
               newPart.text = "";
             }
-            aggregatedResponse.candidates[i].content.parts.push(
+            aggregatedResponse.candidates[candidateIndex].content.parts.push(
               newPart as Part,
             );
           }
         }
       }
+      candidateIndex++;
     }
     if (response.usageMetadata) {
       aggregatedResponse.usageMetadata = response.usageMetadata;


### PR DESCRIPTION
The issues #310 and #309 are caused by candidates not having proper indexing. 

The package assigns it from the response `candidate.index` which is currently `undefined` because it is not defined in the API schema ([found this](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference)) but surprisingly defined [here](https://ai.google.dev/api/generate-content#v1beta.Candidate).

While this PR aims to fix those issues by making its own indexing instead of depending on the server and it works well, I can change the code so it can work with both cases (defined and undefined index)