### PR TITLE
Proposal: Add ability to quickly run starter project on Val Town 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ seamlessly across text, images, and code.
 > app or fetch it remotely at runtime.
 
 ## Get started with the Gemini API
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/googleGeminiAPI)
 
 1.  Go to [Google AI Studio](https://aistudio.google.com/).
 2.  Login with your Google account.


### PR DESCRIPTION
Hey there! 

I’d love to propose adding a [Val Town](https://www.val.town/) badge to the README so new users can spin up a client for the Gemini API in just one click.

I work at Val Town, and it would mean a lot to us to have a place in Gemini's docs or open-source repos. We’re totally open to any tweaks you’d like us to make!

## Proposed badge in README:
[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/googleGeminiAPI)

## In action:
![Clipboard-20250204-193254-690](https://github.com/user-attachments/assets/962596b7-73ba-4841-83e6-333bb62d5258)

## Why this could be helpful:
1.  Gives users instant access to a working example.
2.  Lets them fork and customize the example in a single click.
3.  Helps avoid local development headaches (like node/npm issues) so users can focus on your API instead.

We recently did this with [Steel's Cookbook](https://github.com/steel-dev/steel-cookbook/blob/main/examples/steel-puppeteer-starter/README.md) and they were [super excited about it](https://x.com/hussufo/status/1884332147122766090), so we thought it'd be awesome to bring the same experience to Gemini. We've been experimenting with Gemini a ton internally and this would have definitely helped us when we started!

We’re happy to help maintain this starter on Val Town as your API evolves, or you’re welcome to fork it so you have full control.

This PR should be good to go as-is, but we’d love to hear your thoughts! 😊