### PR TITLE
Fix job cancellation.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
       run: npm run test
 
   node-integration-test:
+    timeout-minutes: 5
     if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:
@@ -64,6 +65,7 @@ jobs:
       run: npm run test:node:integration
 
   web-integration-test:
+    timeout-minutes: 5
     if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: False
       matrix:
         node-version: ['18.x', '20.x']
     steps:
@@ -65,7 +66,6 @@ jobs:
       run: npm run test:node:integration
 
   web-integration-test:
-    timeout-minutes: 5
     if: github.secret_source == 'Actions'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The "cancelled" jobs are caused by one job in the matrix failing, and cancelling the others. We can disable "fail fast" to let each job finish.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures

Or we can just leave it.