### PR TITLE
Version Packages

### DIFF
--- a/.changeset/better-vans-act.md
+++ b/.changeset/better-vans-act.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": minor
----
-
-Breaking change: Fix typo of groundingChunks

--- a/.changeset/brave-cloths-relate.md
+++ b/.changeset/brave-cloths-relate.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": minor
----
-
-Breaking change: Fix typo of 'groundingSupport' -> 'groundingSupports'

--- a/.changeset/dry-pugs-bow.md
+++ b/.changeset/dry-pugs-bow.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": patch
----
-
-Swapped the package manager to npm, in order to take advantage of npm audit fix

--- a/.changeset/flat-gorillas-happen.md
+++ b/.changeset/flat-gorillas-happen.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": patch
----
-
-Fix undefined candidate index.

--- a/.changeset/funny-paws-visit.md
+++ b/.changeset/funny-paws-visit.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": patch
----
-
-Make sure chat api do not send empty text request after encounter any server error that returns empty response. This fixes issue #124 and issue #286.

--- a/.changeset/good-beans-cheat.md
+++ b/.changeset/good-beans-cheat.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": patch
----
-
-update FinishReason enum

--- a/.changeset/lucky-grapes-rest.md
+++ b/.changeset/lucky-grapes-rest.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": patch
----
-
-Fix flaky integration test with tools

--- a/.changeset/thirty-moons-count.md
+++ b/.changeset/thirty-moons-count.md
@@ -1,4 +1,0 @@
----
----
-
-Internal change. Improve node version compatibility in the build script.

--- a/.changeset/young-rivers-shout.md
+++ b/.changeset/young-rivers-shout.md
@@ -1,5 +1,0 @@
----
-"@google/generative-ai": minor
----
-
-The schema types are now more specific, using a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) based on the 'type' field to more accurately define which fields are allowed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @google/generative-ai
 
+## 0.22.0
+
+### Minor Changes
+
+- b546cba: Breaking change: Fix typo of groundingChunks
+- 85621eb: Breaking change: Fix typo of 'groundingSupport' -> 'groundingSupports'
+- 3004d3b: The schema types are now more specific, using a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) based on the 'type' field to more accurately define which fields are allowed.
+
+### Patch Changes
+
+- 864afb7: Swapped the package manager to npm, in order to take advantage of npm audit fix
+- 070bcdc: Fix undefined candidate index.
+- 6a99ed8: Make sure chat api do not send empty text request after encounter any server error that returns empty response. This fixes issue #124 and issue #286.
+- 25d3a92: update FinishReason enum
+- d87cf1d: Fix flaky integration test with tools
+
 ## 0.21.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/generative-ai",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Google AI JavaScript SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This PR is a copy of the one opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to main, this PR will be updated.

# Releases
## @google/generative-ai@0.22.0

### Minor Changes

-   b546cba: Breaking change: Fix typo of groundingChunks
-   85621eb: Breaking change: Fix typo of 'groundingSupport' -> 'groundingSupports'
-   3004d3b: The schema types are now more specific, using a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) based on the 'type' field to more accurately define which fields are allowed.

### Patch Changes

-   864afb7: Swapped the package manager to npm, in order to take advantage of npm audit fix
-   070bcdc: Fix undefined candidate index.
-   6a99ed8: Make sure chat api do not send empty text request after encounter any server error that returns empty response. This fixes issue #124 and issue #286.
-   25d3a92: update FinishReason enum
-   d87cf1d: Fix flaky integration test with tools
