### PR TITLE
Adds streamCallbacks as an optional argument. Fixes #322

### DIFF
--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // Warning: (ae-incompatible-release-tags) The symbol "ArraySchema" is marked as @public, but its signature references "BaseSchema" which is marked as @internal
 //
 // @public
@@ -30,8 +32,6 @@ export interface BooleanSchema extends BaseSchema {
     // (undocumented)
     type: typeof SchemaType.BOOLEAN;
 }
-
-/// <reference types="node" />
 
 // @public
 export interface CachedContent extends CachedContentBase {

--- a/common/api-review/generative-ai.api.md
+++ b/common/api-review/generative-ai.api.md
@@ -514,7 +514,7 @@ export class GenerativeModel {
     countTokens(request: CountTokensRequest | string | Array<string | Part>, requestOptions?: SingleRequestOptions): Promise<CountTokensResponse>;
     embedContent(request: EmbedContentRequest | string | Array<string | Part>, requestOptions?: SingleRequestOptions): Promise<EmbedContentResponse>;
     generateContent(request: GenerateContentRequest | string | Array<string | Part>, requestOptions?: SingleRequestOptions): Promise<GenerateContentResult>;
-    generateContentStream(request: GenerateContentRequest | string | Array<string | Part>, requestOptions?: SingleRequestOptions): Promise<GenerateContentStreamResult>;
+    generateContentStream(request: GenerateContentRequest | string | Array<string | Part>, requestOptions?: SingleRequestOptions, callbacks?: StreamCallbacks): Promise<GenerateContentStreamResult>;
     // (undocumented)
     generationConfig: GenerationConfig;
     // (undocumented)
@@ -816,6 +816,16 @@ export interface StartChatParams extends BaseParams {
     toolConfig?: ToolConfig;
     // (undocumented)
     tools?: Tool[];
+}
+
+// @public
+export interface StreamCallbacks {
+    // (undocumented)
+    onData?: (data: string) => void;
+    // (undocumented)
+    onEnd?: (data: string) => void;
+    // (undocumented)
+    onError?: (error: Error) => void;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "StringSchema" is marked as @public, but its signature references "BaseSchema" which is marked as @internal

--- a/src/methods/generate-content.ts
+++ b/src/methods/generate-content.ts
@@ -21,6 +21,7 @@ import {
   GenerateContentResult,
   GenerateContentStreamResult,
   SingleRequestOptions,
+  StreamCallbacks,
 } from "../../types";
 import { Task, makeModelRequest } from "../requests/request";
 import { addHelpers } from "../requests/response-helpers";
@@ -31,6 +32,7 @@ export async function generateContentStream(
   model: string,
   params: GenerateContentRequest,
   requestOptions: SingleRequestOptions,
+  callbacks?: StreamCallbacks,
 ): Promise<GenerateContentStreamResult> {
   const response = await makeModelRequest(
     model,
@@ -40,7 +42,7 @@ export async function generateContentStream(
     JSON.stringify(params),
     requestOptions,
   );
-  return processStream(response);
+  return processStream(response, callbacks);
 }
 
 export async function generateContent(

--- a/src/models/generative-model.ts
+++ b/src/models/generative-model.ts
@@ -38,6 +38,7 @@ import {
   SafetySetting,
   SingleRequestOptions,
   StartChatParams,
+  StreamCallbacks,
   Tool,
   ToolConfig,
 } from "../../types";
@@ -132,6 +133,7 @@ export class GenerativeModel {
   async generateContentStream(
     request: GenerateContentRequest | string | Array<string | Part>,
     requestOptions: SingleRequestOptions = {},
+    callbacks?: StreamCallbacks
   ): Promise<GenerateContentStreamResult> {
     const formattedParams = formatGenerateContentInput(request);
     const generativeModelRequestOptions: SingleRequestOptions = {
@@ -151,6 +153,7 @@ export class GenerativeModel {
         ...formattedParams,
       },
       generativeModelRequestOptions,
+      callbacks
     );
   }
 

--- a/src/requests/stream-reader.test.ts
+++ b/src/requests/stream-reader.test.ts
@@ -340,6 +340,62 @@ describe("processStream", () => {
     }
     expect(foundCitationMetadata).to.be.true;
   });
+
+  describe("callbacks", () => {
+    it("chunk callbacks were called", (done) => {
+        const fakeResponse = getMockResponseStreaming(
+          "streaming-success-citations.txt",
+        );
+        processStream(fakeResponse as Response, {
+          onData: (data: string) => {
+            expect(data).to.not.be.empty;
+          },
+          onEnd: () => done(),
+        });
+    });
+
+    it("error callbacks were called", (done) => {
+        const fakeResponse = getMockResponseStreaming(
+          "streaming-failure-prompt-blocked-safety.txt",
+        );
+        processStream(fakeResponse as Response, {
+          onError: (error: Error) => {
+            expect(error).to.be.instanceOf(GoogleGenerativeAIError);
+            done();
+          },
+          onEnd: () => done(),
+        });
+    });
+
+    it("end callbacks were called", (done) => {
+        const fakeResponse = getMockResponseStreaming(
+          "streaming-success-basic-reply-short.txt",
+        );
+        processStream(fakeResponse as Response, {
+          onEnd: (data) => {
+            expect(data).to.include("Cheyenne");
+            done();
+          },
+        });
+    });
+
+    it("all callbacks were called", (done) => {
+        const fakeResponse = getMockResponseStreaming(
+          "streaming-success-basic-reply-long.txt",
+        );
+        processStream(fakeResponse as Response, {
+          onEnd: (data) => {
+            expect(data).to.include("**Cats:**");
+            expect(data).to.include("to their owners.");
+            done();
+          },
+          onData: (data: string) => {
+            expect(data).to.not.be.empty;
+          },
+        });
+    });
+  });
+
 });
 
 describe("aggregateResponses", () => {

--- a/types/requests.ts
+++ b/types/requests.ts
@@ -210,6 +210,16 @@ export interface RequestOptions {
 }
 
 /**
+ * Callbacks for streaming responses.
+ * @public
+ */
+export interface StreamCallbacks {
+  onData?: (data: string) => void;
+  onEnd?: (data: string) => void;
+  onError?: (error: Error) => void;
+}
+
+/**
  * Params passed to atomic asynchronous operations.
  * @public
  */


### PR DESCRIPTION
Added `streamCallbacks` as an optional argument to `generateContentStream`. 
This would allow users to not deal with node.js streams and simply get back the text response in callbacks.

```js
   await model.generateContentStream("What is 2 + 2", {}, {
       onData(chunk: string) => console.log(chunk),
      onDone(fullText: string) => console.log(fullText)
   });

```