### PR TITLE
Add support for callbacks on streamed response

### DIFF
--- a/samples/chat.js
+++ b/samples/chat.js
@@ -66,16 +66,36 @@ async function chatStreaming() {
       },
     ],
   });
-  let result = await chat.sendMessageStream("I have 2 dogs in my house.");
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
-  result = await chat.sendMessageStream("How many paws are in my house?");
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
+  let result = await chat.sendMessageStream(
+    "I have 2 dogs in my house.",
+    {
+      onData: (chunk) => {
+        const chunkText = chunk.text();
+        process.stdout.write(chunkText);
+      },
+      onEnd: (response) => {
+        console.log("\nStream ended. Final response:", response.text());
+      },
+      onError: (error) => {
+        console.error("Stream error:", error);
+      },
+    }
+  );
+  result = await chat.sendMessageStream(
+    "How many paws are in my house?",
+    {
+      onData: (chunk) => {
+        const chunkText = chunk.text();
+        process.stdout.write(chunkText);
+      },
+      onEnd: (response) => {
+        console.log("\nStream ended. Final response:", response.text());
+      },
+      onError: (error) => {
+        console.error("Stream error:", error);
+      },
+    }
+  );
   // [END chat_streaming]
 }
 

--- a/samples/text_generation.js
+++ b/samples/text_generation.js
@@ -47,13 +47,18 @@ async function textGenTextOnlyPromptStreaming() {
 
   const prompt = "Write a story about a magic backpack.";
 
-  const result = await model.generateContentStream(prompt);
-
-  // Print text as it comes in.
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
+  const result = await model.generateStreamedResponse(prompt, {
+    onData: (chunk) => {
+      const chunkText = chunk.text();
+      process.stdout.write(chunkText);
+    },
+    onEnd: (response) => {
+      console.log("\nStream ended. Final response:", response.text());
+    },
+    onError: (error) => {
+      console.error("Stream error:", error);
+    },
+  });
   // [END text_gen_text_only_prompt_streaming]
 }
 
@@ -108,13 +113,18 @@ async function textGenMultimodalOneImagePromptStreaming() {
     "image/jpeg",
   );
 
-  const result = await model.generateContentStream([prompt, imagePart]);
-
-  // Print text as it comes in.
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
+  const result = await model.generateStreamedResponse([prompt, imagePart], {
+    onData: (chunk) => {
+      const chunkText = chunk.text();
+      process.stdout.write(chunkText);
+    },
+    onEnd: (response) => {
+      console.log("\nStream ended. Final response:", response.text());
+    },
+    onError: (error) => {
+      console.error("Stream error:", error);
+    },
+  });
   // [END text_gen_multimodal_one_image_prompt_streaming]
 }
 
@@ -177,13 +187,18 @@ async function textGenMultimodalMultiImagePromptStreaming() {
     fileToGenerativePart(`${mediaPath}/firefighter.jpg`, "image/jpeg"),
   ];
 
-  const result = await model.generateContentStream([prompt, ...imageParts]);
-
-  // Print text as it comes in.
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
+  const result = await model.generateStreamedResponse([prompt, ...imageParts], {
+    onData: (chunk) => {
+      const chunkText = chunk.text();
+      process.stdout.write(chunkText);
+    },
+    onEnd: (response) => {
+      console.log("\nStream ended. Final response:", response.text());
+    },
+    onError: (error) => {
+      console.error("Stream error:", error);
+    },
+  });
   // [END text_gen_multimodal_multi_image_prompt_streaming]
 }
 
@@ -293,12 +308,18 @@ async function textGenMultimodalVideoPromptStreaming() {
     },
   };
 
-  const result = await model.generateContentStream([prompt, videoPart]);
-  // Print text as it comes in.
-  for await (const chunk of result.stream) {
-    const chunkText = chunk.text();
-    process.stdout.write(chunkText);
-  }
+  const result = await model.generateStreamedResponse([prompt, videoPart], {
+    onData: (chunk) => {
+      const chunkText = chunk.text();
+      process.stdout.write(chunkText);
+    },
+    onEnd: (response) => {
+      console.log("\nStream ended. Final response:", response.text());
+    },
+    onError: (error) => {
+      console.error("Stream error:", error);
+    },
+  });
   // [END text_gen_multimodal_video_prompt_streaming]
   await fileManager.deleteFile(uploadResult.file.name);
 }

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -142,6 +142,15 @@ export class ChatSession {
    */
   async sendMessageStream(
     request: string | Array<string | Part>,
+    {
+      onData,
+      onEnd,
+      onError,
+    }: {
+      onData?: (chunk: any) => void;
+      onEnd?: (response: any) => void;
+      onError?: (error: any) => void;
+    } = {},
     requestOptions: SingleRequestOptions = {},
   ): Promise<GenerateContentStreamResult> {
     await this._sendPromise;
@@ -203,6 +212,24 @@ export class ChatSession {
           console.error(e);
         }
       });
+
+    streamPromise
+      .then(async (result) => {
+        try {
+          for await (const chunk of result.stream) {
+            if (onData) onData(chunk);
+          }
+          if (onEnd) onEnd(await result.response);
+        } catch (error) {
+          if (onError) onError(error);
+          else throw error;
+        }
+      })
+      .catch((e) => {
+        if (onError) onError(e);
+        else throw e;
+      });
+
     return streamPromise;
   }
 }


### PR DESCRIPTION
Related to #322

Add support for callbacks on streamed responses.

* **`src/models/generative-model.ts`**: Add `generateStreamedResponse` method to support `onData`, `onEnd`, and `onError` callbacks.
* **`src/methods/chat-session.ts`**: Update `sendMessageStream` to support `onData`, `onEnd`, and `onError` callbacks.
* **`samples/chat.js`**: Update `chatStreaming` function to demonstrate callback usage.
* **`samples/text_generation.js`**: Update `textGenTextOnlyPromptStreaming`, `textGenMultimodalOneImagePrompt`, `textGenMultimodalMultiImagePrompt`, and `textGenMultimodalVideoPromptStreaming` functions to demonstrate callback usage.
* **`src/requests/stream-reader.ts`**: Update `processStream` to handle `onData`, `onEnd`, and `onError` callbacks and add `handleCallbacks` function.

