### PR TITLE
Fix ESLint .eslintignore path issue on Windows

### DIFF
--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // Warning: (ae-incompatible-release-tags) The symbol "ArraySchema" is marked as @public, but its signature references "BaseSchema" which is marked as @internal
 //
 // @public
@@ -30,8 +32,6 @@ export interface BooleanSchema extends BaseSchema {
     // (undocumented)
     type: typeof SchemaType.BOOLEAN;
 }
-
-/// <reference types="node" />
 
 // @public
 export interface CachedContent extends CachedContentBase {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/generative-ai",
-  "version": "0.21.0",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/generative-ai",
-      "version": "0.21.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@changesets/cli": "^2.27.1",
@@ -28,6 +28,7 @@
         "chai": "^4.3.10",
         "chai-as-promised": "^7.1.1",
         "chai-deep-equal-ignore-undefined": "^1.1.1",
+        "cross-env": "^7.0.3",
         "eslint": "^8.52.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-unused-imports": "^3.0.0",
@@ -3484,6 +3485,25 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -12175,6 +12195,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
     "server/package.json"
   ],
   "scripts": {
-    "build": "rollup -c && npm run api-report",
-    "test": "npm run lint && npm run test:node:unit",
-    "test:web:integration": "npm run build && npx web-test-runner",
-    "test:node:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"src/**/*.test.ts\"",
-    "test:node:integration": "npm run build && TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"test-integration/node/**/*.test.ts\"",
-    "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
-    "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
-    "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
-    "format": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/run-format.ts",
-    "format:check": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/check-format.ts"
+     "build": "rollup -c && npm run api-report",
+     "test": "npm run lint && npm run test:node:unit",
+     "test:web:integration": "npm run build && npx web-test-runner",
+     "test:node:unit": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha \"src/**/*.test.ts\"",
+     "test:node:integration": "npm run build && cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha \"test-integration/node/**/*.test.ts\"",
+     "lint": "eslint -c .eslintrc.js \"**/*.ts\" --ignore-path .gitignore",
+     "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
+     "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
+     "format": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"nodenext\\\"} npx ts-node scripts/run-format.ts",
+     "format:check": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"nodenext\\\"} npx ts-node scripts/check-format.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -63,6 +63,7 @@
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "chai-deep-equal-ignore-undefined": "^1.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-unused-imports": "^3.0.0",


### PR DESCRIPTION
Fixed issue: #392 #383

Issue:
The issue was in windows npm run test failed

Reason:
On Linux, the path /path/to/project/.gitignore is valid and straightforward.

On Windows, the path C:\path\to\project.gitignore requires proper escaping of backslashes, and the presence of single quotes (') in the path is causing issues.

Solution
I've fixed it by installing cross env and updating the script 

now works in both properly


Windows------>>>>>
Before:
![image](https://github.com/user-attachments/assets/150294ec-b367-4874-919e-5f4fe1c1a1a1)
After:
![image](https://github.com/user-attachments/assets/00314410-3abe-440a-9eea-9139a8a2504a)

Linux---------->>>>>>
![image](https://github.com/user-attachments/assets/a9a2995b-73cc-4cb3-829b-132f0ad4fdbf)

