### PR TITLE
Fix readme numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,38 @@
 # Google AI SDK for JavaScript
 
-The Google AI JavaScript SDK is the easiest way for JavaScript developers to
-build with the Gemini API. The Gemini API gives you access to Gemini
-[models](https://ai.google.dev/models/gemini) created by
-[Google DeepMind](https://deepmind.google/technologies/gemini/#introduction).
-Gemini models are built from the ground up to be multimodal, so you can reason
-seamlessly across text, images, and code.
+The Google AI JavaScript SDK is the easiest way for JavaScript developers to build with the Gemini API. The Gemini API provides access to Gemini [models](https://ai.google.dev/models/gemini) created by [Google DeepMind](https://deepmind.google/technologies/gemini/#introduction). These models are designed to be multimodal, allowing seamless reasoning across text, images, and code.
 
-> [!CAUTION] **Using the Google AI SDK for JavaScript directly from a
-> client-side app is recommended for prototyping only.** If you plan to enable
-> billing, we strongly recommend that you call the Google AI Gemini API only
-> server-side to keep your API key safe. You risk potentially exposing your API
-> key to malicious actors if you embed your API key directly in your JavaScript
-> app or fetch it remotely at runtime.
+> **⚠ CAUTION:** Using the Google AI SDK for JavaScript directly from a client-side app is recommended **for prototyping only**. If you plan to enable billing, we strongly recommend calling the Google AI Gemini API **only on the server-side** to protect your API key from exposure to malicious actors.
 
-## Get started with the Gemini API
+## Get Started with the Gemini API
 
-1.  Go to [Google AI Studio](https://aistudio.google.com/).
-2.  Login with your Google account.
-3.  [Create an API key](https://aistudio.google.com/app/apikey). Note that in
-    Europe the free tier is not available.
-4.  Try the
-    [Node.js quickstart](https://ai.google.dev/tutorials/node_quickstart)
+To begin using the Gemini API, follow these steps:
 
-## Usage example
+1. Go to [Google AI Studio](https://aistudio.google.com/).
+2. Log in with your Google account.
+3. [Create an API key](https://aistudio.google.com/app/apikey). *(Note: In Europe, the free tier is unavailable.)*
+4. Try the [Node.js quickstart](https://ai.google.dev/tutorials/node_quickstart).
 
-See the [Node.js quickstart](https://ai.google.dev/tutorials/node_quickstart)
-for complete code.
+## Installation and Usage
 
-1.  Install the SDK package
+### Install the SDK
 
-```js
+To install the SDK, run:
+
+```sh
 npm install @google/generative-ai
 ```
 
-1.  Initialize the model
+### Initialize the Model
 
 ```js
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 
 const genAI = new GoogleGenerativeAI(process.env.API_KEY);
-
 const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 ```
 
-1.  Run a prompt
+### Run a Prompt
 
 ```js
 const prompt = "Does this look store-bought or homemade?";
@@ -59,40 +47,45 @@ const result = await model.generateContent([prompt, image]);
 console.log(result.response.text());
 ```
 
-## Try out a sample app
+## Try a Sample App
 
-This repository contains sample Node and web apps demonstrating how the SDK can
-access and utilize the Gemini model for various use cases.
+This repository contains sample Node.js and web apps demonstrating how the SDK can interact with the Gemini model for various use cases.
 
-**To try out the sample Node app, follow these steps:**
+### Running the Sample Node App
 
-1.  Check out this repository. \
-    `git clone https://github.com/google/generative-ai-js`
-
-1.  [Obtain an API key](https://makersuite.google.com/app/apikey) to use with
-    the Google AI SDKs.
-
-2.  cd into the `samples` folder and run `npm install`.
-
-3.  Assign your API key to an environment variable: `export API_KEY=MY_API_KEY`.
-
-4.  Open the sample file you're interested in. Example: `text_generation.js`.
-    In the `runAll()` function, comment out any samples you don't want to run.
-
-5.  Run the sample file. Example: `node text_generation.js`.
+1. Clone this repository:
+   ```sh
+   git clone https://github.com/google/generative-ai-js
+   ```
+2. [Obtain an API key](https://makersuite.google.com/app/apikey) to use with the Google AI SDKs.
+3. Navigate to the `samples` folder and install dependencies:
+   ```sh
+   cd samples
+   npm install
+   ```
+4. Assign your API key to an environment variable:
+   ```sh
+   export API_KEY=MY_API_KEY
+   ```
+5. Open the sample file you want to run (e.g., `text_generation.js`).
+   - Inside the `runAll()` function, comment out any samples you don't want to execute.
+6. Run the sample file:
+   ```sh
+   node text_generation.js
+   ```
 
 ## Documentation
 
-See the
-[Gemini API Cookbook](https://github.com/google-gemini/gemini-api-cookbook/) or
-[ai.google.dev](https://ai.google.dev) for complete documentation.
+For complete documentation, see:
+
+- [Gemini API Cookbook](https://github.com/google-gemini/gemini-api-cookbook/)
+- [Google AI Developer Portal](https://ai.google.dev)
 
 ## Contributing
 
-See [Contributing](/docs/contributing.md) for more information on contributing
-to the Google AI JavaScript SDK.
+We welcome contributions! See our [Contributing Guide](/docs/contributing.md) for details on how to contribute to the Google AI JavaScript SDK.
 
 ## License
 
-The contents of this repository are licensed under the
-[Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+This repository is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+

--- a/common/api-review/generative-ai-server.api.md
+++ b/common/api-review/generative-ai-server.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 // Warning: (ae-incompatible-release-tags) The symbol "ArraySchema" is marked as @public, but its signature references "BaseSchema" which is marked as @internal
 //
 // @public
@@ -30,8 +32,6 @@ export interface BooleanSchema extends BaseSchema {
     // (undocumented)
     type: typeof SchemaType.BOOLEAN;
 }
-
-/// <reference types="node" />
 
 // @public
 export interface CachedContent extends CachedContentBase {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/generative-ai",
-  "version": "0.21.0",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/generative-ai",
-      "version": "0.21.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@changesets/cli": "^2.27.1",
@@ -28,6 +28,7 @@
         "chai": "^4.3.10",
         "chai-as-promised": "^7.1.1",
         "chai-deep-equal-ignore-undefined": "^1.1.1",
+        "cross-env": "^7.0.3",
         "eslint": "^8.52.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-unused-imports": "^3.0.0",
@@ -3484,6 +3485,25 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -12175,6 +12195,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
     "server/package.json"
   ],
   "scripts": {
-    "build": "rollup -c && npm run api-report",
-    "test": "npm run lint && npm run test:node:unit",
-    "test:web:integration": "npm run build && npx web-test-runner",
-    "test:node:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"src/**/*.test.ts\"",
-    "test:node:integration": "npm run build && TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"test-integration/node/**/*.test.ts\"",
-    "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
-    "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
-    "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
-    "format": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/run-format.ts",
-    "format:check": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/check-format.ts"
+     "build": "rollup -c && npm run api-report",
+     "test": "npm run lint && npm run test:node:unit",
+     "test:web:integration": "npm run build && npx web-test-runner",
+     "test:node:unit": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha \"src/**/*.test.ts\"",
+     "test:node:integration": "npm run build && cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha \"test-integration/node/**/*.test.ts\"",
+     "lint": "eslint -c .eslintrc.js \"**/*.ts\" --ignore-path .gitignore",
+     "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
+     "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
+     "format": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"nodenext\\\"} npx ts-node scripts/run-format.ts",
+     "format:check": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"nodenext\\\"} npx ts-node scripts/check-format.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -63,6 +63,7 @@
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "chai-deep-equal-ignore-undefined": "^1.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-unused-imports": "^3.0.0",


### PR DESCRIPTION
Fixed issue no: #397 

Improved the readme numbering. Previously it showed 1 for all the steps. 
![image](https://github.com/user-attachments/assets/f16e096a-7489-4ff7-8aca-550697da2e5f)

Now the instructions are clear