### PR TITLE
fixed the import statement for the GoogleGenerativeAI module in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @google/generative-ai
 1.  Initialize the model
 
 ```js
-const { GoogleGenerativeAI } = require("@google/generative-ai");
+import { GoogleGenerativeAI } from "@google/generative-ai";
 
 const genAI = new GoogleGenerativeAI(process.env.API_KEY);
 


### PR DESCRIPTION
fixes #407 

The import statement for the GoogleGenerativeAI module in the readme for SDK installation is modified similarly to the import statement in text_generation.js