### PR TITLE
Fix incorrect command spelling in contribution documentation (#411)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,7 +37,7 @@ Steps to build locally:
 1. Run `npm run test` to run unit tests.
 1. Run `npm run docs` to generate any changes to reference docs (destination dir is docs/reference).
 1. Run `npm run format` to fix formatting and add license headers as needed.
-1. Run `npx @changeset/cli` to generate the changeset summary.
+1. Run `npx @changesets/cli` to generate the changeset summary.
 
 ### Code Reviews
 


### PR DESCRIPTION
This PR fixes a typo in the Contribution process section of the documentation. The command to generate the changeset summary was incorrectly written as:
`npx @changeset/cli`

The correct command is:
`npx @changesets/cli`

**Fixes:**
Updated the documentation to reflect the correct command spelling.

**Related Issue:**
Closes #411

**Testing:**
- Verified the correct package name in the [Changesets documentation](https://github.com/changesets/changesets).
- Ensured the command works without errors.