### PR TITLE
fix: After an API error, all subsequent calls fail with the same error

### DIFF
--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -127,7 +127,14 @@ export class ChatSession {
         }
         finalResult = result;
       });
-    await this._sendPromise;
+    
+    try {
+      await this._sendPromise;
+    } catch (error) {
+      this._sendPromise = Promise.resolve();
+      throw error;
+    }
+
     return finalResult;
   }
 


### PR DESCRIPTION
Fix #417 