### PR TITLE
fix: After an API error, all subsequent calls fail with the same error

### DIFF
--- a/src/methods/chat-session.test.ts
+++ b/src/methods/chat-session.test.ts
@@ -46,6 +46,27 @@ describe("ChatSession", () => {
         match.any,
       );
     });
+    it("generateContent errors should not persist", async () => {
+      const generateContentStub = stub(
+        generateContentMethods,
+        "generateContent",
+      ).rejects("generateContent failed");
+      const chatSession = new ChatSession("MY_API_KEY", "a-model");
+      await expect(chatSession.sendMessage("hello")).to.be.rejected;
+      expect(generateContentStub).to.be.calledWith(
+        "MY_API_KEY",
+        "a-model",
+        match.any,
+      );
+      restore();
+
+      // Subsequent call should succeed.
+      const mockResponse = getMockResponse(
+        "unary-success-basic-reply-short.json",
+      );
+      stub(request, "makeModelRequest").resolves(mockResponse as Response);
+      await expect(chatSession.sendMessage("hello")).to.not.be.rejected;
+    });
   });
   describe("sendMessageRecitationErrorNotAddingResponseToHistory()", () => {
     it("generateContent errors should be catchable", async () => {

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -126,14 +126,13 @@ export class ChatSession {
           }
         }
         finalResult = result;
+      })
+      .catch((e) => {
+        // Resets _sendPromise to avoid subsequent calls failing and throw error.
+        this._sendPromise = Promise.resolve();
+        throw e;
       });
-
-    await this._sendPromise.catch((e) => {
-      // Resets _sendPromise and re-throws the error if it fails
-      this._sendPromise = Promise.resolve();
-      throw e;
-    });
-
+    await this._sendPromise;
     return finalResult;
   }
 

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -128,12 +128,11 @@ export class ChatSession {
         finalResult = result;
       });
 
-    try {
-      await this._sendPromise;
-    } catch (error) {
+    await this._sendPromise.catch((e) => {
+      // Resets _sendPromise and re-throws the error if it fails
       this._sendPromise = Promise.resolve();
-      throw error;
-    }
+      throw e;
+    });
 
     return finalResult;
   }

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -127,7 +127,14 @@ export class ChatSession {
         }
         finalResult = result;
       });
-    await this._sendPromise;
+    
+    try {
+      await this._sendPromise;
+    } catch (error) {
+      this._sendPromise = Promise.resolve();
+      throw error;
+    }
+
     return finalResult;
   }
 

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -127,7 +127,7 @@ export class ChatSession {
         }
         finalResult = result;
       });
-    
+
     try {
       await this._sendPromise;
     } catch (error) {


### PR DESCRIPTION
Fix #417 