### PR TITLE
Compatible with new response formats, supporting "Text", "Audio", "Image" arrays

### DIFF
--- a/common/api-review/generative-ai.api.md
+++ b/common/api-review/generative-ai.api.md
@@ -496,6 +496,7 @@ export interface GenerationConfig {
     presencePenalty?: number;
     responseLogprobs?: boolean;
     responseMimeType?: string;
+    responseModalities?: string[];
     responseSchema?: ResponseSchema;
     // (undocumented)
     stopSequences?: string[];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/generative-ai",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Google AI JavaScript SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/methods/chat-session-helpers.ts
+++ b/src/methods/chat-session-helpers.ts
@@ -39,7 +39,13 @@ const VALID_PART_FIELDS: Array<keyof Part> = [
 const VALID_PARTS_PER_ROLE: { [key in Role]: Array<keyof Part> } = {
   user: ["text", "inlineData"],
   function: ["functionResponse"],
-  model: ["text", "functionCall", "executableCode", "codeExecutionResult"],
+  model: [
+    "text",
+    "inlineData",
+    "functionCall",
+    "executableCode",
+    "codeExecutionResult",
+  ],
   // System instructions shouldn't be in history anyway.
   system: ["text"],
 };

--- a/types/requests.ts
+++ b/types/requests.ts
@@ -122,6 +122,10 @@ export interface GenerationConfig {
    * logprobs to return at each decoding step in the logprobsResult.
    */
   logprobs?: number;
+  /**
+   * Compatible with new response formats, supporting "Text", "Audio", "Image" arrays.
+   */
+  responseModalities?: string[];
 }
 
 /**


### PR DESCRIPTION
The new `gemini-2.0-flash-exp-image-generation` model requires the `responseModalities: ["Text", "Image"]` parameter.

Currently, in the conversation model, the model does not accept the inlineData parameter, and `gemini-2.0-flash-exp-image-generation` will generate inlineData images during the conversation process, so compatibility needs to be handled for this.