### PR TITLE
added cross-env to make npm run test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "build": "rollup -c && npm run api-report",
     "test": "npm run lint && npm run test:node:unit",
     "test:web:integration": "npm run build && npx web-test-runner",
-    "test:node:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"src/**/*.test.ts\"",
-    "test:node:integration": "npm run build && TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"test-integration/node/**/*.test.ts\"",
-    "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
+    "test:node:unit": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" mocha \"src/**/*.test.ts\"",
+    "test:node:integration": "npm run build && cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" mocha \"test-integration/node/**/*.test.ts\"",
+    "lint": "eslint -c .eslintrc.js \"**/*.ts\" --ignore-path \"./.gitignore\"",
     "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
     "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
-    "format": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/run-format.ts",
-    "format:check": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/check-format.ts"
+    "format": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"nodenext\\\"}\" npx ts-node scripts/run-format.ts",
+    "format:check": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"nodenext\\\"}\" npx ts-node scripts/check-format.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -63,6 +63,7 @@
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "chai-deep-equal-ignore-undefined": "^1.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-unused-imports": "^3.0.0",


### PR DESCRIPTION
This PR attempts to fix #394

The process fails when attempting to run `npm run test` on a Windows system. This PR adds a `cross-env` dependency in `package.json` that enables the script to be run on both Unix and Windows.