### PR TITLE
Added error throw for when user enters multiple messages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "build": "rollup -c && npm run api-report",
     "test": "npm run lint && npm run test:node:unit",
     "test:web:integration": "npm run build && npx web-test-runner",
-    "test:node:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"src/**/*.test.ts\"",
-    "test:node:integration": "npm run build && TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha \"test-integration/node/**/*.test.ts\"",
-    "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
+    "test:node:unit": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" mocha \"src/**/*.test.ts\"",
+    "test:node:integration": "npm run build && cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" mocha \"test-integration/node/**/*.test.ts\"",
+    "lint": "eslint -c .eslintrc.js \"**/*.ts\" --ignore-path \"./.gitignore\"",
     "api-report": "api-extractor run -c api-extractor.json --local --verbose && api-extractor run -c api-extractor.server.json --local --verbose",
     "docs": "npm run build && npx api-documenter markdown -i ./temp/main -o ./docs/reference/main && npx api-documenter markdown -i ./temp/server -o ./docs/reference/server",
-    "format": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/run-format.ts",
-    "format:check": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"nodenext\"}' npx ts-node scripts/check-format.ts"
+    "format": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"nodenext\\\"}\" npx ts-node scripts/run-format.ts",
+    "format:check": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"nodenext\\\"}\" npx ts-node scripts/check-format.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -63,6 +63,7 @@
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
     "chai-deep-equal-ignore-undefined": "^1.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-unused-imports": "^3.0.0",

--- a/src/methods/chat-session.test.ts
+++ b/src/methods/chat-session.test.ts
@@ -91,7 +91,7 @@ describe("ChatSession", () => {
         "generateContentStream",
       ).resolves();
       const chatSession = new ChatSession("MY_API_KEY", "a-model");
-      await chatSession.sendMessageStream("hello");
+      await expect(chatSession.sendMessageStream("hello")).to.be.fulfilled;
       expect(generateContentStreamStub).to.be.calledWith(
         "MY_API_KEY",
         "a-model",

--- a/src/methods/chat-session.test.ts
+++ b/src/methods/chat-session.test.ts
@@ -46,6 +46,15 @@ describe("ChatSession", () => {
         match.any,
       );
     });
+    it("sendMessage() should reset messageInProgress flag after resolving promise", async () => {
+      const mockResponse = getMockResponse(
+        "unary-success-basic-reply-short.json",
+      );
+      stub(request, "makeModelRequest").resolves(mockResponse as Response);
+      const chatSession = new ChatSession("MY_API_KEY", "a-model");
+      await chatSession.sendMessage("hello");
+      expect(chatSession["_messageInProgress"]).to.be.false;
+    });
   });
   describe("sendMessageRecitationErrorNotAddingResponseToHistory()", () => {
     it("generateContent errors should be catchable", async () => {
@@ -74,6 +83,22 @@ describe("ChatSession", () => {
       await clock.runAllAsync();
       expect(consoleStub).to.not.be.called;
       clock.restore();
+    });
+    it("sendMessageStream() should reset messageInProgress flag after resolving promise", async () => {
+      const consoleStub = stub(console, "error");
+      const generateContentStreamStub = stub(
+        generateContentMethods,
+        "generateContentStream",
+      ).resolves();
+      const chatSession = new ChatSession("MY_API_KEY", "a-model");
+      await chatSession.sendMessageStream("hello");
+      expect(generateContentStreamStub).to.be.calledWith(
+        "MY_API_KEY",
+        "a-model",
+        match.any,
+      );
+      expect(consoleStub).to.not.be.called;
+      expect(chatSession["_messageInProgress"]).to.be.false;
     });
     it("downstream sendPromise errors should log but not throw", async () => {
       const clock = useFakeTimers();

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -45,6 +45,7 @@ export class ChatSession {
   private _apiKey: string;
   private _history: Content[] = [];
   private _sendPromise: Promise<void> = Promise.resolve();
+  private _messageInProgress: boolean = false;
 
   constructor(
     apiKey: string,
@@ -81,6 +82,12 @@ export class ChatSession {
     request: string | Array<string | Part>,
     requestOptions: SingleRequestOptions = {},
   ): Promise<GenerateContentResult> {
+    if (this._messageInProgress) {
+      console.warn(
+        "sendMessage() was called while another message was in progress, this may lead to unexpected behavior. ",
+      );
+    }
+    this._messageInProgress = true;
     await this._sendPromise;
     const newContent = formatNewContent(request);
     const generateContentRequest: GenerateContentRequest = {
@@ -126,6 +133,7 @@ export class ChatSession {
           }
         }
         finalResult = result;
+        this._messageInProgress = false;
       });
     await this._sendPromise;
     return finalResult;
@@ -144,6 +152,12 @@ export class ChatSession {
     request: string | Array<string | Part>,
     requestOptions: SingleRequestOptions = {},
   ): Promise<GenerateContentStreamResult> {
+    if (this._messageInProgress) {
+      console.warn(
+        "sendMessage() was called while another message was in progress, this may lead to unexpected behavior. ",
+      );
+    }
+    this._messageInProgress = true;
     await this._sendPromise;
     const newContent = formatNewContent(request);
     const generateContentRequest: GenerateContentRequest = {
@@ -202,7 +216,9 @@ export class ChatSession {
           // downstream from streamPromise, so they should not throw.
           console.error(e);
         }
+        this._messageInProgress = false;
       });
+    this._messageInProgress = false;
     return streamPromise;
   }
 }

--- a/src/methods/chat-session.ts
+++ b/src/methods/chat-session.ts
@@ -83,8 +83,8 @@ export class ChatSession {
     requestOptions: SingleRequestOptions = {},
   ): Promise<GenerateContentResult> {
     if (this._messageInProgress) {
-      console.warn(
-        "sendMessage() was called while another message was in progress, this may lead to unexpected behavior. ",
+      throw new Error(
+        "sendMessage() was called while another message was in progress, this may lead to unexpected behavior.",
       );
     }
     this._messageInProgress = true;
@@ -133,6 +133,8 @@ export class ChatSession {
           }
         }
         finalResult = result;
+      })
+      .finally(() => {
         this._messageInProgress = false;
       });
     await this._sendPromise;
@@ -153,8 +155,8 @@ export class ChatSession {
     requestOptions: SingleRequestOptions = {},
   ): Promise<GenerateContentStreamResult> {
     if (this._messageInProgress) {
-      console.warn(
-        "sendMessage() was called while another message was in progress, this may lead to unexpected behavior. ",
+      throw new Error(
+        "sendMessageStream() was called while another message was in progress, this may lead to unexpected behavior.",
       );
     }
     this._messageInProgress = true;
@@ -216,7 +218,6 @@ export class ChatSession {
           // downstream from streamPromise, so they should not throw.
           console.error(e);
         }
-        this._messageInProgress = false;
       });
     this._messageInProgress = false;
     return streamPromise;


### PR DESCRIPTION
This PR aims to address #28 
Added a `_messageInProgress` boolean flag under the `ChatSession` class. This flag will be set to `false` initially, and will be set to `true` when `chatSession.sendMessage()` or `chatSession.sendMessageStream` is called. If either function is run again before the initial one completes, it will throw an error.